### PR TITLE
[feat/#20] 바텀시트 컴포넌트 개발 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
+        "@gorhom/bottom-sheet": "^5.2.8",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -2390,6 +2391,45 @@
       },
       "bin": {
         "excpretty": "build/cli.js"
+      }
+    },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.8.tgz",
+      "integrity": "sha512-+N27SMpbBxXZQ/IA2nlEV6RGxL/qSFHKfdFKcygvW+HqPG5jVNb1OqehLQsGfBP+Up42i0gW5ppI+DhpB7UCzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.16.0 || >=4.0.0-"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
+    "@gorhom/bottom-sheet": "^5.2.8",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -1,96 +1,34 @@
-import { Image, Pressable, ScrollView, Text, View } from "react-native";
+import { BottomSheetView } from "@gorhom/bottom-sheet";
+import { Pressable, ScrollView, Text } from "react-native";
+
+import { useBottomSheetStore } from "@/shared/model/bottom-sheet";
 
 export default function HomeScreen() {
+  const openBottomSheet = useBottomSheetStore((s) => s.open);
+
   return (
     <ScrollView
-      className="flex-1 bg-white dark:bg-zinc-950"
-      contentContainerClassName="px-5 pt-6 pb-10"
+      className="flex-1 bg-surface-app"
+      contentContainerClassName="flex-1 items-center justify-center px-screen"
       showsVerticalScrollIndicator={false}
     >
-      {/* Header */}
-      <View className="mb-5 overflow-hidden rounded-3xl bg-zinc-900 px-5 py-6 dark:bg-zinc-900">
-        <View className="flex-row items-center justify-between">
-          <View className="flex-1 pr-4">
-            <Text className="text-sm font-medium text-zinc-300">오늘 뭐 먹지?</Text>
-            <Text className="mt-1 text-3xl font-extrabold tracking-tight text-white">
-              What&apos;s in my fridge
-            </Text>
-            <Text className="mt-2 text-sm leading-5 text-zinc-300">
-              냉장고 속 재료로 만들 수 있는 레시피를 빠르게 찾아보세요.
-            </Text>
-          </View>
-
-          <Image
-            source={require("@assets/images/partial-react-logo.png")}
-            className="h-20 w-20 opacity-90"
-            resizeMode="contain"
-          />
-        </View>
-
-        <View className="mt-5 flex-row gap-3">
-          <Pressable
-            className="flex-1 rounded-2xl bg-white px-4 py-3 active:opacity-90"
-            onPress={() => alert("준비중입니다")}
-          >
-            <Text className="text-center text-sm font-bold text-zinc-900">빠른 추가</Text>
-          </Pressable>
-
-          <Pressable
-            className="flex-1 rounded-2xl bg-zinc-800 px-4 py-3 active:opacity-90"
-            onPress={() => alert("준비중입니다")}
-          >
-            <Text className="text-center text-sm font-semibold text-white">탐색</Text>
-          </Pressable>
-        </View>
-      </View>
-
-      {/* Summary cards */}
-      <View className="mb-6 flex-row gap-3">
-        <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-          <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">냉장고</Text>
-          <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">12</Text>
-          <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">아이템</Text>
-        </View>
-        <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-          <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">임박</Text>
-          <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">3</Text>
-          <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">유통기한</Text>
-        </View>
-        <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-          <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">추천</Text>
-          <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">7</Text>
-          <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">레시피</Text>
-        </View>
-      </View>
-
-      {/* Section: Recent items (placeholder UI) */}
-      <View className="mb-3 flex-row items-end justify-between">
-        <Text className="text-lg font-extrabold text-zinc-900 dark:text-white">최근 추가</Text>
-        <Text className="text-sm font-semibold text-zinc-500 dark:text-zinc-400">전체보기</Text>
-      </View>
-
-      <View className="gap-3">
-        {[
-          { title: "계란", meta: "유통기한 2일 남음" },
-          { title: "우유", meta: "유통기한 5일 남음" },
-          { title: "양파", meta: "상온 보관" },
-        ].map((item) => (
-          <View
-            key={item.title}
-            className="flex-row items-center justify-between rounded-3xl bg-white p-4 shadow-sm ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-800"
-          >
-            <View className="flex-1 pr-3">
-              <Text className="text-base font-bold text-zinc-900 dark:text-white">
-                {item.title}
+      <Pressable
+        className="rounded-button bg-primary px-8 py-4 active:opacity-90"
+        onPress={() =>
+          openBottomSheet(
+            <BottomSheetView style={{ paddingHorizontal: 20, paddingVertical: 24 }}>
+              <Text className="text-xl font-extrabold text-content-primary">
+                바텀시트
               </Text>
-              <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{item.meta}</Text>
-            </View>
-            <View className="h-10 w-10 items-center justify-center rounded-2xl bg-zinc-100 dark:bg-zinc-800">
-              <Text className="text-base font-black text-zinc-700 dark:text-zinc-200">+</Text>
-            </View>
-          </View>
-        ))}
-      </View>
+              <Text className="mt-2 text-sm text-content-secondary">
+                바깥 영역 탭 또는 아래로 스와이프하면 닫힙니다
+              </Text>
+            </BottomSheetView>,
+          )
+        }
+      >
+        <Text className="text-base font-bold text-white">바텀시트 열기</Text>
+      </Pressable>
     </ScrollView>
   );
 }

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -17,9 +17,7 @@ export default function HomeScreen() {
         onPress={() =>
           openBottomSheet(
             <BottomSheetView style={{ paddingHorizontal: 20, paddingVertical: 24 }}>
-              <Text className="text-xl font-extrabold text-content-primary">
-                바텀시트
-              </Text>
+              <Text className="text-xl font-extrabold text-content-primary">바텀시트</Text>
               <Text className="mt-2 text-sm text-content-secondary">
                 바깥 영역 탭 또는 아래로 스와이프하면 닫힙니다
               </Text>

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import "react-native-reanimated";
 
 import "../../global.css";
 
+import { BottomSheetProvider } from "@/app/_providers";
 import { useColorScheme } from "@/shared/lib/hooks/use-color-scheme";
 
 export const unstable_settings = {
@@ -15,11 +16,13 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <BottomSheetProvider>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </BottomSheetProvider>
   );
 }

--- a/src/app/_providers/BottomSheetProvider.tsx
+++ b/src/app/_providers/BottomSheetProvider.tsx
@@ -1,0 +1,30 @@
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+
+import { useBottomSheetStore } from "@/shared/model/bottom-sheet";
+import { BottomSheet } from "@/shared/ui/bottom-sheet";
+
+interface BottomSheetProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * App 레이어: store와 BottomSheet를 조립합니다.
+ * Store를 구독하고, 순수 BottomSheet에 props를 전달합니다.
+ */
+export function BottomSheetProvider({ children }: BottomSheetProviderProps) {
+  const content = useBottomSheetStore((s) => s.content);
+  const close = useBottomSheetStore((s) => s.close);
+  const isOpen = content !== null;
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <BottomSheetModalProvider>
+        {children}
+        <BottomSheet isOpen={isOpen} onClose={close}>
+          {content}
+        </BottomSheet>
+      </BottomSheetModalProvider>
+    </GestureHandlerRootView>
+  );
+}

--- a/src/app/_providers/index.ts
+++ b/src/app/_providers/index.ts
@@ -1,0 +1,1 @@
+export { BottomSheetProvider } from "./BottomSheetProvider";

--- a/src/shared/config/tokens.ts
+++ b/src/shared/config/tokens.ts
@@ -93,12 +93,12 @@ export type SemanticColorKey = keyof typeof semanticColors;
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const semanticRadius = {
-  sm: primitiveRadius["sm"],
-  md: primitiveRadius["md"],
-  lg: primitiveRadius["lg"],
-  xl: primitiveRadius["xl"],
+  sm: primitiveRadius.sm,
+  md: primitiveRadius.md,
+  lg: primitiveRadius.lg,
+  xl: primitiveRadius.xl,
   "2xl": primitiveRadius["2xl"],
-  full: primitiveRadius["full"],
+  full: primitiveRadius.full,
 } as const;
 
 export type SemanticRadiusKey = keyof typeof semanticRadius;

--- a/src/shared/model/bottom-sheet/index.ts
+++ b/src/shared/model/bottom-sheet/index.ts
@@ -1,0 +1,1 @@
+export { useBottomSheetStore } from "./store";

--- a/src/shared/model/bottom-sheet/store.ts
+++ b/src/shared/model/bottom-sheet/store.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { create } from "zustand";
+
+interface BottomSheetStore {
+  content: ReactNode | null;
+  open: (content: ReactNode) => void;
+  close: () => void;
+}
+
+export const useBottomSheetStore = create<BottomSheetStore>((set) => ({
+  content: null,
+  open: (content) => set({ content }),
+  close: () => set({ content: null }),
+}));

--- a/src/shared/ui/bottom-sheet/BottomSheet.styles.ts
+++ b/src/shared/ui/bottom-sheet/BottomSheet.styles.ts
@@ -1,0 +1,26 @@
+import { Dimensions, StyleSheet } from "react-native";
+
+import { semanticColors, semanticRadius, semanticSpacing } from "@/shared/config/tokens";
+
+export const bottomSheetStyles = StyleSheet.create({
+  background: {
+    backgroundColor: semanticColors["surface-card"],
+    borderTopLeftRadius: semanticRadius["2xl"],
+    borderTopRightRadius: semanticRadius["2xl"],
+  },
+  handleIndicator: {
+    backgroundColor: semanticColors["stroke-default"],
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+  },
+  content: {
+    flex: 1,
+    paddingBottom: semanticSpacing.lg,
+  },
+});
+
+export const BOTTOM_SHEET_MAX_HEIGHT_RATIO = 0.9;
+
+export const maxDynamicContentSize =
+  Dimensions.get("window").height * BOTTOM_SHEET_MAX_HEIGHT_RATIO;

--- a/src/shared/ui/bottom-sheet/BottomSheet.styles.ts
+++ b/src/shared/ui/bottom-sheet/BottomSheet.styles.ts
@@ -1,4 +1,4 @@
-import { Dimensions, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 
 import { semanticColors, semanticRadius, semanticSpacing } from "@/shared/config/tokens";
 
@@ -21,6 +21,3 @@ export const bottomSheetStyles = StyleSheet.create({
 });
 
 export const BOTTOM_SHEET_MAX_HEIGHT_RATIO = 0.9;
-
-export const maxDynamicContentSize =
-  Dimensions.get("window").height * BOTTOM_SHEET_MAX_HEIGHT_RATIO;

--- a/src/shared/ui/bottom-sheet/BottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/BottomSheet.tsx
@@ -1,0 +1,34 @@
+import { BottomSheetHandle, BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
+import { bottomSheetStyles, maxDynamicContentSize } from "./BottomSheet.styles";
+import { BottomSheetBackdropCloseable } from "./BottomSheetBackdrop";
+import { useBottomSheetModal } from "./useBottomSheetModal";
+
+export interface BottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function BottomSheet({ isOpen, onClose, children }: BottomSheetProps) {
+  const { modalRef, handleDismiss } = useBottomSheetModal(isOpen, onClose);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <BottomSheetModal
+      ref={modalRef}
+      enableDynamicSizing
+      enablePanDownToClose
+      handleComponent={BottomSheetHandle}
+      handleIndicatorStyle={bottomSheetStyles.handleIndicator}
+      backdropComponent={BottomSheetBackdropCloseable}
+      backgroundStyle={bottomSheetStyles.background}
+      maxDynamicContentSize={maxDynamicContentSize}
+      onDismiss={handleDismiss}
+    >
+      <BottomSheetView style={bottomSheetStyles.content}>{children}</BottomSheetView>
+    </BottomSheetModal>
+  );
+}

--- a/src/shared/ui/bottom-sheet/BottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/BottomSheet.tsx
@@ -1,5 +1,7 @@
 import { BottomSheetHandle, BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
-import { bottomSheetStyles, maxDynamicContentSize } from "./BottomSheet.styles";
+import { useWindowDimensions } from "react-native";
+
+import { BOTTOM_SHEET_MAX_HEIGHT_RATIO, bottomSheetStyles } from "./BottomSheet.styles";
 import { BottomSheetBackdropCloseable } from "./BottomSheetBackdrop";
 import { useBottomSheetModal } from "./useBottomSheetModal";
 
@@ -10,11 +12,9 @@ export interface BottomSheetProps {
 }
 
 export function BottomSheet({ isOpen, onClose, children }: BottomSheetProps) {
+  const { height } = useWindowDimensions();
   const { modalRef, handleDismiss } = useBottomSheetModal(isOpen, onClose);
-
-  if (!isOpen) {
-    return null;
-  }
+  const maxDynamicContentSize = height * BOTTOM_SHEET_MAX_HEIGHT_RATIO;
 
   return (
     <BottomSheetModal

--- a/src/shared/ui/bottom-sheet/BottomSheetBackdrop.tsx
+++ b/src/shared/ui/bottom-sheet/BottomSheetBackdrop.tsx
@@ -1,0 +1,14 @@
+import type { BottomSheetBackdropProps } from "@gorhom/bottom-sheet";
+import { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
+
+export function BottomSheetBackdropCloseable(props: BottomSheetBackdropProps) {
+  return (
+    <BottomSheetBackdrop
+      {...props}
+      appearsOnIndex={0}
+      disappearsOnIndex={-1}
+      pressBehavior="close"
+      opacity={0.5}
+    />
+  );
+}

--- a/src/shared/ui/bottom-sheet/README.md
+++ b/src/shared/ui/bottom-sheet/README.md
@@ -1,0 +1,100 @@
+# BottomSheet
+
+바텀시트 UI 컴포넌트. Store를 알지 못하며, `isOpen` / `onClose` / `children`만 받아 그립니다.
+
+## 아키텍처
+
+```
+shared/ui/bottom-sheet     → 순수 UI (BottomSheet 컴포넌트)
+shared/model/bottom-sheet  → 상태 관리 (useBottomSheetStore)
+app/providers             → store + BottomSheet 조립 (BottomSheetProvider)
+```
+
+- **BottomSheet**: props만 받아 렌더링하는 순수 컴포넌트
+- **useBottomSheetStore**: `open()`, `close()`, `content` 상태
+- **BottomSheetProvider**: 앱 루트 `_layout.tsx`에서 store와 BottomSheet를 연결
+
+## 사용법
+
+### 1. 바텀시트 열기
+
+`useBottomSheetStore`의 `open()`에 **ReactNode**를 넘깁니다.
+
+```tsx
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import { useBottomSheetStore } from "@/shared/model/bottom-sheet";
+
+function MyScreen() {
+  const openBottomSheet = useBottomSheetStore((s) => s.open);
+
+  return (
+    <Pressable
+      onPress={() =>
+        openBottomSheet(
+          <BottomSheetScrollView
+            contentContainerStyle={{
+              paddingHorizontal: 20,
+              paddingTop: 24,
+              paddingBottom: 40,
+            }}
+          >
+            <Text>바텀시트 내용</Text>
+          </BottomSheetScrollView>,
+        )
+      }
+    >
+      <Text>바텀시트 열기</Text>
+    </Pressable>
+  );
+}
+```
+
+### 2. 스크롤 가능한 내용
+
+스크롤이 필요하면 `BottomSheetScrollView`를 사용합니다.
+
+```tsx
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+
+openBottomSheet(
+  <BottomSheetScrollView
+    contentContainerStyle={{
+      paddingHorizontal: 20,
+      paddingTop: 24,
+      paddingBottom: 40,
+    }}
+  >
+    {/* 긴 내용 */}
+  </BottomSheetScrollView>,
+);
+```
+
+### 3. 스크롤 없는 정적 내용
+
+`BottomSheetView` 또는 일반 `View`를 사용할 수 있습니다.
+
+```tsx
+import { BottomSheetView } from "@gorhom/bottom-sheet";
+
+openBottomSheet(
+  <BottomSheetView style={{ padding: 20 }}>
+    <Text>짧은 내용</Text>
+  </BottomSheetView>,
+);
+```
+
+## 닫기
+
+- **백드롭 탭**: 바깥 어두운 영역 탭 시 닫힘
+- **아래로 스와이프**: 시트를 아래로 당기면 닫힘
+- **프로그래밍 방식**: `useBottomSheetStore`의 `close()` 호출
+
+```tsx
+const close = useBottomSheetStore((s) => s.close);
+close(); // 바텀시트 닫기
+```
+
+## 전제 조건
+
+- 앱 루트 `_layout.tsx`에서 `BottomSheetProvider`로 감싸져 있어야 합니다.
+- `BottomSheetProvider`는 `GestureHandlerRootView`와 `BottomSheetModalProvider`를 포함합니다.

--- a/src/shared/ui/bottom-sheet/index.ts
+++ b/src/shared/ui/bottom-sheet/index.ts
@@ -1,0 +1,1 @@
+export { BottomSheet, type BottomSheetProps } from "./BottomSheet";

--- a/src/shared/ui/bottom-sheet/useBottomSheetModal.ts
+++ b/src/shared/ui/bottom-sheet/useBottomSheetModal.ts
@@ -1,0 +1,18 @@
+import type { BottomSheetModal } from "@gorhom/bottom-sheet";
+import { useCallback, useEffect, useRef } from "react";
+
+export function useBottomSheetModal(isOpen: boolean, onClose: () => void) {
+  const modalRef = useRef<BottomSheetModal>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      modalRef.current?.present();
+    }
+  }, [isOpen]);
+
+  const handleDismiss = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  return { modalRef, handleDismiss };
+}

--- a/src/shared/ui/bottom-sheet/useBottomSheetModal.ts
+++ b/src/shared/ui/bottom-sheet/useBottomSheetModal.ts
@@ -7,6 +7,8 @@ export function useBottomSheetModal(isOpen: boolean, onClose: () => void) {
   useEffect(() => {
     if (isOpen) {
       modalRef.current?.present();
+    } else {
+      modalRef.current?.dismiss();
     }
   }, [isOpen]);
 


### PR DESCRIPTION
## 요약

- 순수 바텀시트 UI 컴포넌트 + FSD 구조로 리팩터링
- Store와 UI 분리, app 레이어에서 조립

## 관련 이슈

- Closes #20 

## 작업 세부사항

### 아키텍처
- **shared/ui/bottom-sheet**: 순수 UI (`isOpen`/`onClose`/`children`만 props)
- **shared/model/bottom-sheet**: Zustand store (`open`, `close`, `content`)
- **app/_providers**: store + BottomSheet 조립 (BottomSheetProvider)

### shared/bottom-sheet폴더 구조 
- `BottomSheet.tsx` — 메인 컴포넌트
- `BottomSheetBackdrop.tsx` — 백드롭 (외부 탭 시 시트 닫아주는 컴포넌트)
- `BottomSheet.styles.ts` — 스타일 분리
- `useBottomSheetModal.ts` — present/dismiss 로직 훅
- `index.ts` — public API re-export

### 버그 수정
- `enableDynamicSizing` 사용 시 백드롭 미노출 → `appearsOnIndex={0}`, `disappearsOnIndex={-1}` 적용

### 기타
- `shared/ui/bottom-sheet/README.md` — 사용법 문서 추가

## 참고사항

- `BottomSheetModalProvider`는 앱 루트 `_layout.tsx`에서 `BottomSheetProvider`로 감싸야 함 => 현재 적용시켜놓았음 