### PR TITLE
[feat/#33] 검색 페이지 및 레시피 상세 페이지 구현 (목데이터 적용)

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -23,6 +23,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="search"
+        options={{
+          title: "레시피",
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="magnifyingglass" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/src/app/(tabs)/search.tsx
+++ b/src/app/(tabs)/search.tsx
@@ -1,0 +1,5 @@
+import { SearchPage } from "@/pages/search/ui/SearchPage";
+
+export default function SearchRoute() {
+  return <SearchPage />;
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -20,6 +20,7 @@ export default function RootLayout() {
       <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="recipe/[recipeId]" options={{ headerShown: false }} />
         </Stack>
         <StatusBar style="auto" />
       </ThemeProvider>

--- a/src/app/recipe/[recipeId].tsx
+++ b/src/app/recipe/[recipeId].tsx
@@ -1,0 +1,9 @@
+import { useLocalSearchParams } from "expo-router";
+
+import { RecipeDetailPage } from "@/pages/recipe-detail/ui/RecipeDetailPage";
+
+export default function RecipeDetailRoute() {
+  const { recipeId } = useLocalSearchParams<{ recipeId: string }>();
+
+  return <RecipeDetailPage recipeId={recipeId} />;
+}

--- a/src/entities/recipe/model/recipe.types.ts
+++ b/src/entities/recipe/model/recipe.types.ts
@@ -1,0 +1,40 @@
+/** 재료 */
+export interface Ingredient {
+  name: string;
+  /** 사용자가 보유한 재료인지 여부 */
+  owned: boolean;
+}
+
+/** 조리 단계 */
+export interface CookingStep {
+  step: number;
+  description: string;
+  /** 소요 시간 (분) */
+  duration: number;
+  /** 조리 단계 이미지 (선택) */
+  imageUrl?: string;
+}
+
+/** 레시피 */
+export interface Recipe {
+  id: string;
+  title: string;
+  /** 대표 이미지 */
+  imageUrl: string;
+  /** 카테고리 태그 (예: 한식, 양식) */
+  category: string;
+  /** 해시태그 목록 */
+  tags: string[];
+  /** 조리 시간 (분) */
+  cookingTime: number;
+  /** 인분 */
+  servings: number;
+  /** 난이도 */
+  difficulty: "쉬움" | "보통" | "어려움";
+  /** 레시피 설명 */
+  description: string;
+  /** 재료 목록 */
+  ingredients: Ingredient[];
+  /** 조리 순서 */
+  steps: CookingStep[];
+}

--- a/src/pages/recipe-detail/ui/RecipeDetailPage.tsx
+++ b/src/pages/recipe-detail/ui/RecipeDetailPage.tsx
@@ -1,0 +1,210 @@
+import { Image, ScrollView, Text, View } from "react-native";
+
+import type { Recipe } from "@/entities/recipe/model/recipe.types";
+
+// ────────────────────────────────────────────────────────
+// 더미 데이터 (API 연동 전 UI 확인용)
+// ────────────────────────────────────────────────────────
+const DUMMY_RECIPES: Record<string, Recipe> = {
+  "1": {
+    id: "1",
+    title: "김치찌개",
+    imageUrl: "https://images.unsplash.com/photo-1498654896293-37aacf113fd9?w=600",
+    category: "한식",
+    tags: ["한식", "찌개", "얼큰"],
+    cookingTime: 20,
+    servings: 2,
+    difficulty: "쉬움",
+    description:
+      "냉장고에 남은 김치로 만드는 칼칼하고 시원한 찌개. 돼지고기와 두부가 들어가 더욱 든든합니다.",
+    ingredients: [
+      { name: "김치", owned: true },
+      { name: "돼지고기", owned: true },
+      { name: "두부", owned: true },
+      { name: "대파", owned: false },
+      { name: "고추장", owned: false },
+    ],
+    steps: [
+      {
+        step: 1,
+        description: "김치를 먹기 좋게 썰고, 돼지고기는 얇게 슬라이스합니다.",
+        duration: 5,
+      },
+      {
+        step: 2,
+        description: "냄비에 참기름을 두르고 돼지고기와 김치를 함께 볶습니다.",
+        duration: 8,
+      },
+      {
+        step: 3,
+        description: "물 2컵을 붓고 끓기 시작하면 고추장과 간장으로 간을 맞춥니다.",
+        duration: 10,
+        imageUrl: "https://images.unsplash.com/photo-1498654896293-37aacf113fd9?w=400",
+      },
+      { step: 4, description: "두부를 큼직하게 썰어 넣고 5분 더 끓입니다.", duration: 5 },
+      { step: 5, description: "대파를 송송 썰어 얹고 불을 끄면 완성입니다.", duration: 2 },
+    ],
+  },
+  "2": {
+    id: "2",
+    title: "비빔밥",
+    imageUrl: "https://images.unsplash.com/photo-1553163147-622ab57be1c7?w=600",
+    category: "한식",
+    tags: ["한식", "밥", "건강"],
+    cookingTime: 25,
+    servings: 1,
+    difficulty: "보통",
+    description: "형형색색 나물과 고추장의 매콤한 하모니. 영양 가득한 한 그릇입니다.",
+    ingredients: [
+      { name: "밥", owned: true },
+      { name: "당근", owned: true },
+      { name: "시금치", owned: true },
+      { name: "계란", owned: false },
+      { name: "고추장", owned: false },
+      { name: "참기름", owned: false },
+    ],
+    steps: [
+      { step: 1, description: "각종 나물을 준비하고 데칩니다.", duration: 10 },
+      {
+        step: 2,
+        description: "밥 위에 나물을 올리고 고추장, 참기름을 넣어 비빕니다.",
+        duration: 5,
+      },
+    ],
+  },
+  "3": {
+    id: "3",
+    title: "라멘",
+    imageUrl: "https://images.unsplash.com/photo-1557872943-16a5ac26437e?w=600",
+    category: "일식",
+    tags: ["일식", "면", "따뜻한"],
+    cookingTime: 30,
+    servings: 1,
+    difficulty: "보통",
+    description: "진한 돈코츠 육수와 쫄깃한 면발의 조화.",
+    ingredients: [
+      { name: "라멘면", owned: true },
+      { name: "돼지고기", owned: true },
+      { name: "계란", owned: true },
+    ],
+    steps: [
+      { step: 1, description: "육수를 끓입니다.", duration: 15 },
+      { step: 2, description: "면을 삶고 토핑을 올립니다.", duration: 10 },
+    ],
+  },
+};
+
+interface RecipeDetailPageProps {
+  recipeId: string;
+}
+
+export function RecipeDetailPage({ recipeId }: RecipeDetailPageProps) {
+  const recipe = DUMMY_RECIPES[recipeId];
+
+  if (!recipe) {
+    return (
+      <View className="flex-1 items-center justify-center bg-surface-app">
+        <Text className="text-base text-content-secondary">레시피를 찾을 수 없습니다.</Text>
+      </View>
+    );
+  }
+
+  const ownedIngredients = recipe.ingredients.filter((i) => i.owned);
+  const missingIngredients = recipe.ingredients.filter((i) => !i.owned);
+
+  return (
+    <ScrollView className="flex-1 bg-surface-app" showsVerticalScrollIndicator={false}>
+      {/* 히어로 이미지 */}
+      <View className="relative aspect-[4/3]">
+        <Image source={{ uri: recipe.imageUrl }} className="h-full w-full" resizeMode="cover" />
+        {/* 태그 오버레이 */}
+        <View className="absolute bottom-4 left-4">
+          <Text className="text-xs text-white">{recipe.tags.map((t) => `#${t}`).join("  ")}</Text>
+          <Text className="mt-1 text-2xl font-extrabold text-white">{recipe.title}</Text>
+        </View>
+      </View>
+
+      <View className="px-screen py-6">
+        {/* 메타 정보 */}
+        <View className="flex-row items-center gap-4">
+          <Text className="text-sm text-content-secondary">⏱ {recipe.cookingTime}분</Text>
+          <Text className="text-sm text-content-secondary">👤 {recipe.servings}인분</Text>
+          <Text className="text-sm text-content-secondary">🔥 {recipe.difficulty}</Text>
+        </View>
+
+        {/* 설명 */}
+        <Text className="mt-4 text-sm leading-5 text-content-dark">{recipe.description}</Text>
+
+        {/* 구분선 */}
+        <View className="my-6 h-px bg-stroke-default" />
+
+        {/* 재료 */}
+        <Text className="text-lg font-bold text-content-primary">재료</Text>
+
+        {/* 보유 재료 */}
+        <View className="mt-3">
+          <Text className="text-sm font-semibold text-status-fresh">
+            ✓ 보유 재료 ({ownedIngredients.length})
+          </Text>
+          <View className="mt-2 flex-row flex-wrap gap-2">
+            {ownedIngredients.map((ing) => (
+              <View
+                key={ing.name}
+                className="rounded-tag border border-status-fresh-border bg-status-fresh-bg px-3 py-1"
+              >
+                <Text className="text-xs text-status-fresh">{ing.name}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {/* 부족한 재료 */}
+        {missingIngredients.length > 0 && (
+          <View className="mt-4">
+            <Text className="text-sm font-semibold text-status-expiring">
+              ✕ 부족한 재료 ({missingIngredients.length})
+            </Text>
+            <View className="mt-2 flex-row flex-wrap gap-2">
+              {missingIngredients.map((ing) => (
+                <View
+                  key={ing.name}
+                  className="rounded-tag border border-status-expiring-border bg-status-expiring-bg px-3 py-1"
+                >
+                  <Text className="text-xs text-status-expiring">{ing.name}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+
+        {/* 구분선 */}
+        <View className="my-6 h-px bg-stroke-default" />
+
+        {/* 조리 순서 */}
+        <Text className="text-lg font-bold text-content-primary">조리 순서</Text>
+        <View className="mt-4 gap-6">
+          {recipe.steps.map((s) => (
+            <View key={s.step} className="flex-row gap-3">
+              {/* 스텝 번호 */}
+              <View className="h-8 w-8 items-center justify-center rounded-full bg-primary">
+                <Text className="text-sm font-bold text-white">{s.step}</Text>
+              </View>
+              {/* 스텝 설명 */}
+              <View className="flex-1">
+                <Text className="text-sm leading-5 text-content-primary">{s.description}</Text>
+                <Text className="mt-1 text-xs text-content-secondary">⏱ {s.duration}분</Text>
+                {s.imageUrl && (
+                  <Image
+                    source={{ uri: s.imageUrl }}
+                    className="mt-3 aspect-video w-full rounded-card"
+                    resizeMode="cover"
+                  />
+                )}
+              </View>
+            </View>
+          ))}
+        </View>
+      </View>
+    </ScrollView>
+  );
+}

--- a/src/pages/search/ui/SearchPage.tsx
+++ b/src/pages/search/ui/SearchPage.tsx
@@ -1,0 +1,154 @@
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { ScrollView, Text, View } from "react-native";
+
+import type { Recipe } from "@/entities/recipe/model/recipe.types";
+import type { Category } from "@/shared/ui/CategoryFilter";
+import { CategoryFilter } from "@/shared/ui/CategoryFilter";
+import { SearchBar } from "@/shared/ui/SearchBar";
+import { RecipeList } from "@/widgets/RecipeList";
+
+// ────────────────────────────────────────────────────────
+// 더미 데이터 (API 연동 전 UI 확인용)
+// ────────────────────────────────────────────────────────
+const DUMMY_RECIPES: Recipe[] = [
+  {
+    id: "1",
+    title: "김치찌개",
+    imageUrl: "https://images.unsplash.com/photo-1498654896293-37aacf113fd9?w=400",
+    category: "한식",
+    tags: ["한식", "찌개", "얼큰"],
+    cookingTime: 20,
+    servings: 2,
+    difficulty: "쉬움",
+    description:
+      "냉장고에 남은 김치로 만드는 칼칼하고 시원한 찌개. 돼지고기와 두부가 들어가 더욱 든든합니다.",
+    ingredients: [
+      { name: "김치", owned: true },
+      { name: "돼지고기", owned: true },
+      { name: "두부", owned: true },
+      { name: "대파", owned: false },
+      { name: "고추장", owned: false },
+    ],
+    steps: [
+      {
+        step: 1,
+        description: "김치를 먹기 좋게 썰고, 돼지고기는 얇게 슬라이스합니다.",
+        duration: 5,
+      },
+      {
+        step: 2,
+        description: "냄비에 참기름을 두르고 돼지고기와 김치를 함께 볶습니다.",
+        duration: 8,
+      },
+      {
+        step: 3,
+        description: "물 2컵을 붓고 끓기 시작하면 고추장과 간장으로 간을 맞춥니다.",
+        duration: 10,
+        imageUrl: "https://images.unsplash.com/photo-1498654896293-37aacf113fd9?w=400",
+      },
+      { step: 4, description: "두부를 큼직하게 썰어 넣고 5분 더 끓입니다.", duration: 5 },
+      { step: 5, description: "대파를 송송 썰어 얹고 불을 끄면 완성입니다.", duration: 2 },
+    ],
+  },
+  {
+    id: "2",
+    title: "비빔밥",
+    imageUrl: "https://images.unsplash.com/photo-1553163147-622ab57be1c7?w=400",
+    category: "한식",
+    tags: ["한식", "밥", "건강"],
+    cookingTime: 25,
+    servings: 1,
+    difficulty: "보통",
+    description: "형형색색 나물과 고추장의 매콤한 하모니. 영양 가득한 한 그릇입니다.",
+    ingredients: [
+      { name: "밥", owned: true },
+      { name: "당근", owned: true },
+      { name: "시금치", owned: true },
+      { name: "계란", owned: false },
+      { name: "고추장", owned: false },
+      { name: "참기름", owned: false },
+    ],
+    steps: [
+      { step: 1, description: "각종 나물을 준비하고 데칩니다.", duration: 10 },
+      {
+        step: 2,
+        description: "밥 위에 나물을 올리고 고추장, 참기름을 넣어 비빕니다.",
+        duration: 5,
+      },
+    ],
+  },
+  {
+    id: "3",
+    title: "라멘",
+    imageUrl: "https://images.unsplash.com/photo-1557872943-16a5ac26437e?w=400",
+    category: "일식",
+    tags: ["일식", "면", "따뜻한"],
+    cookingTime: 30,
+    servings: 1,
+    difficulty: "보통",
+    description: "진한 돈코츠 육수와 쫄깃한 면발의 조화.",
+    ingredients: [
+      { name: "라멘면", owned: true },
+      { name: "돼지고기", owned: true },
+      { name: "계란", owned: true },
+    ],
+    steps: [
+      { step: 1, description: "육수를 끓입니다.", duration: 15 },
+      { step: 2, description: "면을 삶고 토핑을 올립니다.", duration: 10 },
+    ],
+  },
+];
+
+export function SearchPage() {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
+
+  // 간단한 클라이언트 사이드 필터링
+  const filteredRecipes = DUMMY_RECIPES.filter((recipe) => {
+    const matchesCategory = selectedCategory === "전체" || recipe.category === selectedCategory;
+    const matchesSearch =
+      searchQuery === "" ||
+      recipe.title.includes(searchQuery) ||
+      recipe.ingredients.some((i) => i.name.includes(searchQuery));
+    return matchesCategory && matchesSearch;
+  });
+
+  const ownedCount = filteredRecipes.length;
+
+  return (
+    <ScrollView
+      className="flex-1 bg-surface-app"
+      contentContainerClassName="pb-24 px-screen pt-14"
+      showsVerticalScrollIndicator={false}
+    >
+      {/* 헤더 */}
+      <Text className="mb-4 text-3xl font-extrabold text-content-primary">레시피</Text>
+
+      {/* 검색바 */}
+      <SearchBar value={searchQuery} onChangeText={setSearchQuery} />
+
+      {/* 카테고리 필터 */}
+      <View className="mt-4">
+        <CategoryFilter selected={selectedCategory} onSelect={setSelectedCategory} />
+      </View>
+
+      {/* 섹션 타이틀 */}
+      <View className="mt-6 mb-3 flex-row items-center gap-2">
+        <Text className="text-base font-bold text-content-primary">
+          냉장고 재료로 만들 수 있어요
+        </Text>
+        <View className="rounded-tag bg-stroke-default px-2 py-0.5">
+          <Text className="text-xs text-content-secondary">{ownedCount}개</Text>
+        </View>
+      </View>
+
+      {/* 레시피 리스트 */}
+      <RecipeList
+        recipes={filteredRecipes}
+        onPressRecipe={(recipe) => router.push(`/recipe/${recipe.id}` as any)}
+      />
+    </ScrollView>
+  );
+}

--- a/src/shared/ui/CategoryFilter/CategoryFilter.tsx
+++ b/src/shared/ui/CategoryFilter/CategoryFilter.tsx
@@ -1,0 +1,37 @@
+import { Pressable, ScrollView, Text } from "react-native";
+
+const CATEGORIES = ["전체", "한식", "양식", "중식", "일식"] as const;
+
+export type Category = (typeof CATEGORIES)[number];
+
+interface CategoryFilterProps {
+  selected: Category;
+  onSelect: (category: Category) => void;
+}
+
+export function CategoryFilter({ selected, onSelect }: CategoryFilterProps) {
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-2">
+      {CATEGORIES.map((cat) => {
+        const isActive = cat === selected;
+        return (
+          <Pressable
+            key={cat}
+            onPress={() => onSelect(cat)}
+            className={`rounded-tag px-4 py-2 ${
+              isActive ? "bg-primary" : "border border-stroke-default bg-surface-card"
+            }`}
+          >
+            <Text
+              className={`text-sm font-semibold ${
+                isActive ? "text-white" : "text-content-secondary"
+              }`}
+            >
+              {cat}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/src/shared/ui/CategoryFilter/index.ts
+++ b/src/shared/ui/CategoryFilter/index.ts
@@ -1,0 +1,2 @@
+export type { Category } from "./CategoryFilter";
+export { CategoryFilter } from "./CategoryFilter";

--- a/src/shared/ui/RecipeCard/RecipeCard.tsx
+++ b/src/shared/ui/RecipeCard/RecipeCard.tsx
@@ -1,0 +1,51 @@
+import { Image, Pressable, Text, View } from "react-native";
+
+import type { Recipe } from "@/entities/recipe/model/recipe.types";
+
+interface RecipeCardProps {
+  recipe: Recipe;
+  onPress?: () => void;
+}
+
+export function RecipeCard({ recipe, onPress }: RecipeCardProps) {
+  /** 보유 재료만 표시, 최대 3개 + 나머지 개수 */
+  const ownedIngredients = recipe.ingredients.filter((i) => i.owned);
+  const visibleTags = ownedIngredients.slice(0, 3);
+  const remainingCount = ownedIngredients.length - visibleTags.length;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-1 overflow-hidden rounded-card bg-surface-card active:opacity-90"
+    >
+      {/* 썸네일 */}
+      <View className="relative aspect-[4/3]">
+        <Image source={{ uri: recipe.imageUrl }} className="h-full w-full" resizeMode="cover" />
+        {/* 재료 태그 오버레이 */}
+        <View className="absolute bottom-2 left-2 flex-row gap-1">
+          {visibleTags.map((ing) => (
+            <View key={ing.name} className="rounded-tag bg-tag-bg px-2 py-1">
+              <Text className="text-2xs text-tag-text">{ing.name}</Text>
+            </View>
+          ))}
+          {remainingCount > 0 && (
+            <View className="rounded-tag bg-tag-bg px-2 py-1">
+              <Text className="text-2xs text-tag-text">+{remainingCount}</Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* 정보 영역 */}
+      <View className="p-card">
+        <Text className="text-base font-bold text-content-primary" numberOfLines={1}>
+          {recipe.title}
+        </Text>
+        <View className="mt-1 flex-row items-center gap-2">
+          <Text className="text-xs text-content-secondary">⏱ {recipe.cookingTime}분</Text>
+          <Text className="text-xs text-content-secondary">👤 {recipe.difficulty}</Text>
+        </View>
+      </View>
+    </Pressable>
+  );
+}

--- a/src/shared/ui/RecipeCard/index.ts
+++ b/src/shared/ui/RecipeCard/index.ts
@@ -1,0 +1,1 @@
+export { RecipeCard } from "./RecipeCard";

--- a/src/shared/ui/SearchBar/SearchBar.tsx
+++ b/src/shared/ui/SearchBar/SearchBar.tsx
@@ -1,0 +1,29 @@
+import { TextInput, View } from "react-native";
+
+import { IconSymbol } from "@/shared/ui/icon-symbol";
+
+interface SearchBarProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder?: string;
+}
+
+export function SearchBar({
+  value,
+  onChangeText,
+  placeholder = "레시피 또는 재료 검색...",
+}: SearchBarProps) {
+  return (
+    <View className="flex-row items-center rounded-input border border-stroke-default bg-surface-card px-4 py-3">
+      <IconSymbol name="magnifyingglass" size={20} color="#9E9E9E" style={{ marginRight: 8 }} />
+      <TextInput
+        className="flex-1 text-base text-content-primary"
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor="#B0A99F"
+        returnKeyType="search"
+      />
+    </View>
+  );
+}

--- a/src/shared/ui/SearchBar/index.ts
+++ b/src/shared/ui/SearchBar/index.ts
@@ -1,0 +1,1 @@
+export { SearchBar } from "./SearchBar";

--- a/src/shared/ui/icon-symbol.tsx
+++ b/src/shared/ui/icon-symbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   "paperplane.fill": "send",
   "chevron.left.forwardslash.chevron.right": "code",
   "chevron.right": "chevron-right",
+  magnifyingglass: "search",
 } as IconMapping;
 
 /**

--- a/src/widgets/RecipeList/RecipeList.tsx
+++ b/src/widgets/RecipeList/RecipeList.tsx
@@ -1,0 +1,21 @@
+import { View } from "react-native";
+
+import type { Recipe } from "@/entities/recipe/model/recipe.types";
+import { RecipeCard } from "@/shared/ui/RecipeCard";
+
+interface RecipeListProps {
+  recipes: Recipe[];
+  onPressRecipe?: (recipe: Recipe) => void;
+}
+
+export function RecipeList({ recipes, onPressRecipe }: RecipeListProps) {
+  return (
+    <View className="flex-row flex-wrap gap-3">
+      {recipes.map((recipe) => (
+        <View key={recipe.id} className="w-[48%]">
+          <RecipeCard recipe={recipe} onPress={() => onPressRecipe?.(recipe)} />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/src/widgets/RecipeList/index.ts
+++ b/src/widgets/RecipeList/index.ts
@@ -1,0 +1,1 @@
+export { RecipeList } from "./RecipeList";


### PR DESCRIPTION
- SearchBar, CategoryFilter, RecipeCard 공통 컴포넌트 추가
- Recipe, Ingredient, CookingStep 타입 정의 및 적용
- RecipeList 위젯 구현
- 검색 페이지 UI 구현 (설계 확인을 위해 임시 목데이터 사용)
- 레시피 상세 페이지 UI 구현 (설계 확인을 위해 임시 목데이터 사용)
- 탭 네비게이션에 레시피 탭 추가 및 동적 라우트 연결
- icon-symbol에 검색 아이콘(magnifyingglass) 매핑 추가
* 참고: 백엔드 API 연동 전이므로, SearchPage와 RecipeDetailPage에 선언된 DUMMY_RECIPES를 통해 UI만 표시되도록 작업했습니다.

## 요약
검색 탭 화면과 레시피 상세 페이지의 UI를 구현하고, 탭 바 네비게이션을 연동했습니다. (API 연동 전 목데이터 적용)
- 

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #33 

## 작업 세부사항
1. **공통 UI 컴포넌트 추가** (`src/shared/ui/`)
    - `SearchBar`: 돋보기 아이콘이 포함된 검색창 컴포넌트
    - `CategoryFilter`: 가로 스크롤 가능한 필터 태그 (전체, 한식, 양식 등)
    - `RecipeCard`: 디자인 스펙에 맞춘 레시피 카드 (썸네일, 재료 태그, 난이도 등 표시)
2. **도메인 모델 구조 세팅** (`src/entities/recipe/`)
    - `Recipe`, `Ingredient`, `CookingStep` 인터페이스 타입 정의
3. **위젯 및 페이지 조립** (`src/widgets/`, `src/pages/`)
    - `RecipeList` 위젯: 2열 그리드로 레시피 카드를 묶어서 렌더링
    - `SearchPage`: 메인 검색 탭 화면 구성
    - `RecipeDetailPage`: 보유/부족 재료 및 조리 순서 UI를 포함한 상세 화면 구성
4. **네비게이션 및 라우팅 연결** (`src/app/`)
    - `_layout.tsx`: 레시피 상세 화면 진입을 위한 스택 추가 (`recipe/[recipeId]`)
    - `(tabs)/_layout.tsx`: 탭 바에 검색 탭 스크린 추가
    - `icon-symbol.tsx`: `magnifyingglass` SF Symbol 매핑 추가
- 

## 참고사항
- API 연동 전 UI 확인을 위해 `SearchPage`와 `RecipeDetailPage` 내부에 **목데이터(`DUMMY_RECIPES`)를 하드코딩**하여 화면을 그렸습니다.
- 추후 백엔드 API 연동 시 상태 관리 로직(React-Query 등)은 `features` 계층으로 분리하여 주입될 예정입니다.
- 리뷰어: `@gemini-code-assist`