### PR TITLE
[feat/#29] 토스트 메시지 구현

### DIFF
--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -1,123 +1,179 @@
+import { tokens } from "@/shared/config/tokens";
+import { useBottomSheetStore } from "@/shared/model/bottom-sheet";
+import { useToastStore } from "@/shared/model/toast";
+import { ToastMessage } from "@/shared/ui/toast";
 import { BottomSheetView } from "@gorhom/bottom-sheet";
 import { router } from "expo-router";
 import { Image, Pressable, ScrollView, Text, View } from "react-native";
-import { useBottomSheetStore } from "@/shared/model/bottom-sheet";
 
 export default function HomeScreen() {
   const openBottomSheet = useBottomSheetStore((s) => s.open);
+  const showToast = useToastStore((s) => s.show);
 
   return (
-    <ScrollView
-      className="flex-1 bg-surface-app"
-      contentContainerClassName="flex-1 items-center justify-center px-screen"
-      showsVerticalScrollIndicator={false}
-    >
-      {/* Header */}
-      <View className="mb-5 overflow-hidden rounded-3xl bg-zinc-900 px-5 py-6 dark:bg-zinc-900">
-        <View className="flex-row items-center justify-between">
-          <View className="flex-1 pr-4">
-            <Text className="text-sm font-medium text-zinc-300">오늘 뭐 먹지?</Text>
-            <Text className="mt-1 text-3xl font-extrabold tracking-tight text-white">
-              What&apos;s in my fridge
-            </Text>
-            <Text className="mt-2 text-sm leading-5 text-zinc-300">
-              냉장고 속 재료로 만들 수 있는 레시피를 빠르게 찾아보세요.
-            </Text>
-          </View>
-
-          <Image
-            source={require("@assets/images/partial-react-logo.png")}
-            className="h-20 w-20 opacity-90"
-            resizeMode="contain"
-          />
-        </View>
-
-        <View className="mt-5 flex-row gap-3">
-          <Pressable
-            className="flex-1 rounded-2xl bg-white px-4 py-3 active:opacity-90"
-            onPress={() => alert("준비중입니다")}
-          >
-            <Text className="text-center text-sm font-bold text-zinc-900">빠른 추가</Text>
-          </Pressable>
-
-          <Pressable
-            className="flex-1 rounded-2xl bg-zinc-800 px-4 py-3 active:opacity-90"
-            onPress={() => alert("준비중입니다")}
-          >
-            <Text className="text-center text-sm font-semibold text-white">탐색</Text>
-          </Pressable>
-        </View>
-      </View>
-
-      {/* Summary cards */}
-      <View className="mb-6 flex-row gap-3">
-        <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-          <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">냉장고</Text>
-          <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">12</Text>
-          <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">아이템</Text>
-        </View>
-        <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-          <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">임박</Text>
-          <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">3</Text>
-          <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">유통기한</Text>
-        </View>
-        <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-          <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">추천</Text>
-          <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">7</Text>
-          <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">레시피</Text>
-        </View>
-      </View>
-
-      {/* [테스트] BackButton 컴포넌트 확인 */}
-      <Pressable
-        className="mb-6 w-full rounded-2xl border border-zinc-200 bg-zinc-100 px-4 py-3 active:opacity-70"
-        onPress={() => router.push("/test-back-button" as never)}
+    <View className="flex-1">
+      <ScrollView
+        className="flex-1 bg-surface-app"
+        contentContainerClassName="items-center px-screen pb-10"
+        showsVerticalScrollIndicator={false}
       >
-        <Text className="text-center text-sm font-bold text-zinc-700">🔙 뒤로가기 버튼 테스트</Text>
-      </Pressable>
-
-      {/* Section: Recent items (placeholder UI) */}
-      <View className="w-full mb-3 flex-row items-end justify-between">
-        <Text className="text-lg font-extrabold text-zinc-900 dark:text-white">최근 추가</Text>
-        <Text className="text-sm font-semibold text-zinc-500 dark:text-zinc-400">전체보기</Text>
-      </View>
-
-      <View className="w-full gap-3 mb-6">
-        {[
-          { title: "계란", meta: "유통기한 2일 남음" },
-          { title: "우유", meta: "유통기한 5일 남음" },
-          { title: "양파", meta: "상온 보관" },
-        ].map((item) => (
-          <View
-            key={item.title}
-            className="flex-row items-center justify-between rounded-3xl bg-white p-4 shadow-sm ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-800"
-          >
-            <View className="flex-1 pr-3">
-              <Text className="text-base font-bold text-zinc-900 dark:text-white">
-                {item.title}
+        {/* Header */}
+        <View className="mb-5 overflow-hidden rounded-3xl bg-zinc-900 px-5 py-6 dark:bg-zinc-900">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-1 pr-4">
+              <Text className="text-sm font-medium text-zinc-300">
+                오늘 뭐 먹지?
               </Text>
-              <Text className="text-sm text-zinc-500">{item.meta}</Text>
+              <Text className="mt-1 text-3xl font-extrabold tracking-tight text-white">
+                What&apos;s in my fridge
+              </Text>
+              <Text className="mt-2 text-sm leading-5 text-zinc-300">
+                냉장고 속 재료로 만들 수 있는 레시피를 빠르게 찾아보세요.
+              </Text>
             </View>
-          </View>
-        ))}
-      </View>
 
-      {/* develop 브랜치에서 넘어온 바텀시트 테스트 버튼 */}
-      <Pressable
-        className="w-full rounded-button bg-primary px-8 py-4 active:opacity-90 mb-10"
-        onPress={() =>
-          openBottomSheet(
-            <BottomSheetView style={{ paddingHorizontal: 20, paddingVertical: 24 }}>
-              <Text className="text-xl font-extrabold text-content-primary">바텀시트</Text>
-              <Text className="mt-2 text-sm text-content-secondary">
-                바깥 영역 탭 또는 아래로 스와이프하면 닫힙니다
+            <Image
+              source={require("@assets/images/partial-react-logo.png")}
+              className="h-20 w-20 opacity-90"
+              resizeMode="contain"
+            />
+          </View>
+
+          <View className="mt-5 flex-row gap-3">
+            <Pressable
+              className="flex-1 rounded-2xl bg-white px-4 py-3 active:opacity-90"
+              onPress={() => alert("준비중입니다")}
+            >
+              <Text className="text-center text-sm font-bold text-zinc-900">
+                빠른 추가
               </Text>
-            </BottomSheetView>,
-          )
-        }
-      >
-        <Text className="text-base text-center font-bold text-white">바텀시트 열기</Text>
-      </Pressable>
-    </ScrollView>
+            </Pressable>
+
+            <Pressable
+              className="flex-1 rounded-2xl bg-zinc-800 px-4 py-3 active:opacity-90"
+              onPress={() => alert("준비중입니다")}
+            >
+              <Text className="text-center text-sm font-semibold text-white">
+                탐색
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {/* Summary cards */}
+        <View className="mb-6 flex-row gap-3">
+          <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
+            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+              냉장고
+            </Text>
+            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">
+              12
+            </Text>
+            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              아이템
+            </Text>
+          </View>
+          <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
+            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+              임박
+            </Text>
+            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">
+              3
+            </Text>
+            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              유통기한
+            </Text>
+          </View>
+          <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
+            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+              추천
+            </Text>
+            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">
+              7
+            </Text>
+            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              레시피
+            </Text>
+          </View>
+        </View>
+
+        {/* [테스트] BackButton 컴포넌트 확인 */}
+        <Pressable
+          className="mb-6 w-full rounded-2xl border border-zinc-200 bg-zinc-100 px-4 py-3 active:opacity-70"
+          onPress={() => router.push("/test-back-button" as never)}
+        >
+          <Text className="text-center text-sm font-bold text-zinc-700">
+            🔙 뒤로가기 버튼 테스트
+          </Text>
+        </Pressable>
+
+        {/* Section: Recent items (placeholder UI) */}
+        <View className="w-full mb-3 flex-row items-end justify-between">
+          <Text className="text-lg font-extrabold text-zinc-900 dark:text-white">
+            최근 추가
+          </Text>
+          <Text className="text-sm font-semibold text-zinc-500 dark:text-zinc-400">
+            전체보기
+          </Text>
+        </View>
+
+        <View className="w-full gap-3 mb-6">
+          {[
+            { title: "계란", meta: "유통기한 2일 남음" },
+            { title: "우유", meta: "유통기한 5일 남음" },
+            { title: "양파", meta: "상온 보관" },
+          ].map((item) => (
+            <View
+              key={item.title}
+              className="flex-row items-center justify-between rounded-3xl bg-white p-4 shadow-sm ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-800"
+            >
+              <View className="flex-1 pr-3">
+                <Text className="text-base font-bold text-zinc-900 dark:text-white">
+                  {item.title}
+                </Text>
+                <Text className="text-sm text-zinc-500">{item.meta}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        {/* 토스트 메시지 테스트 버튼 */}
+        <Pressable
+          className="w-full rounded-button px-xl py-md active:opacity-90 mb-md"
+          style={{ backgroundColor: tokens.color["status-fresh"] }}
+          onPress={() => showToast("토스트 메시지 테스트!")}
+        >
+          <Text className="text-base text-center font-bold text-white">
+            토스트 메시지 테스트 버튼
+          </Text>
+        </Pressable>
+
+        {/* develop 브랜치에서 넘어온 바텀시트 테스트 버튼 */}
+        <Pressable
+          className="w-full rounded-button bg-primary px-8 py-4 active:opacity-90 mb-10"
+          onPress={() =>
+            openBottomSheet(
+              <BottomSheetView
+                style={{ paddingHorizontal: 20, paddingVertical: 24 }}
+              >
+                <Text className="text-xl font-extrabold text-content-primary">
+                  바텀시트
+                </Text>
+                <Text className="mt-2 text-sm text-content-secondary">
+                  바깥 영역 탭 또는 아래로 스와이프하면 닫힙니다
+                </Text>
+              </BottomSheetView>,
+            )
+          }
+        >
+          <Text className="text-base text-center font-bold text-white">
+            바텀시트 열기
+          </Text>
+        </Pressable>
+      </ScrollView>
+
+      {/* 토스트 메시지 컴포넌트: absolute로 고정되어 레이아웃에 영향 없음 */}
+      <ToastMessage />
+    </View>
   );
 }

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -1,10 +1,10 @@
+import { BottomSheetView } from "@gorhom/bottom-sheet";
+import { router } from "expo-router";
+import { Image, Pressable, ScrollView, Text, View } from "react-native";
 import { tokens } from "@/shared/config/tokens";
 import { useBottomSheetStore } from "@/shared/model/bottom-sheet";
 import { useToastStore } from "@/shared/model/toast";
 import { ToastMessage } from "@/shared/ui/toast";
-import { BottomSheetView } from "@gorhom/bottom-sheet";
-import { router } from "expo-router";
-import { Image, Pressable, ScrollView, Text, View } from "react-native";
 
 export default function HomeScreen() {
   const openBottomSheet = useBottomSheetStore((s) => s.open);
@@ -21,9 +21,7 @@ export default function HomeScreen() {
         <View className="mb-5 overflow-hidden rounded-3xl bg-zinc-900 px-5 py-6 dark:bg-zinc-900">
           <View className="flex-row items-center justify-between">
             <View className="flex-1 pr-4">
-              <Text className="text-sm font-medium text-zinc-300">
-                오늘 뭐 먹지?
-              </Text>
+              <Text className="text-sm font-medium text-zinc-300">오늘 뭐 먹지?</Text>
               <Text className="mt-1 text-3xl font-extrabold tracking-tight text-white">
                 What&apos;s in my fridge
               </Text>
@@ -44,18 +42,14 @@ export default function HomeScreen() {
               className="flex-1 rounded-2xl bg-white px-4 py-3 active:opacity-90"
               onPress={() => alert("준비중입니다")}
             >
-              <Text className="text-center text-sm font-bold text-zinc-900">
-                빠른 추가
-              </Text>
+              <Text className="text-center text-sm font-bold text-zinc-900">빠른 추가</Text>
             </Pressable>
 
             <Pressable
               className="flex-1 rounded-2xl bg-zinc-800 px-4 py-3 active:opacity-90"
               onPress={() => alert("준비중입니다")}
             >
-              <Text className="text-center text-sm font-semibold text-white">
-                탐색
-              </Text>
+              <Text className="text-center text-sm font-semibold text-white">탐색</Text>
             </Pressable>
           </View>
         </View>
@@ -63,37 +57,19 @@ export default function HomeScreen() {
         {/* Summary cards */}
         <View className="mb-6 flex-row gap-3">
           <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
-              냉장고
-            </Text>
-            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">
-              12
-            </Text>
-            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-              아이템
-            </Text>
+            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">냉장고</Text>
+            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">12</Text>
+            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">아이템</Text>
           </View>
           <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
-              임박
-            </Text>
-            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">
-              3
-            </Text>
-            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-              유통기한
-            </Text>
+            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">임박</Text>
+            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">3</Text>
+            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">유통기한</Text>
           </View>
           <View className="flex-1 rounded-3xl bg-zinc-100 p-4 dark:bg-zinc-900">
-            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
-              추천
-            </Text>
-            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">
-              7
-            </Text>
-            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-              레시피
-            </Text>
+            <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">추천</Text>
+            <Text className="mt-1 text-2xl font-extrabold text-zinc-900 dark:text-white">7</Text>
+            <Text className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">레시피</Text>
           </View>
         </View>
 
@@ -109,12 +85,8 @@ export default function HomeScreen() {
 
         {/* Section: Recent items (placeholder UI) */}
         <View className="w-full mb-3 flex-row items-end justify-between">
-          <Text className="text-lg font-extrabold text-zinc-900 dark:text-white">
-            최근 추가
-          </Text>
-          <Text className="text-sm font-semibold text-zinc-500 dark:text-zinc-400">
-            전체보기
-          </Text>
+          <Text className="text-lg font-extrabold text-zinc-900 dark:text-white">최근 추가</Text>
+          <Text className="text-sm font-semibold text-zinc-500 dark:text-zinc-400">전체보기</Text>
         </View>
 
         <View className="w-full gap-3 mb-6">
@@ -153,12 +125,8 @@ export default function HomeScreen() {
           className="w-full rounded-button bg-primary px-8 py-4 active:opacity-90 mb-10"
           onPress={() =>
             openBottomSheet(
-              <BottomSheetView
-                style={{ paddingHorizontal: 20, paddingVertical: 24 }}
-              >
-                <Text className="text-xl font-extrabold text-content-primary">
-                  바텀시트
-                </Text>
+              <BottomSheetView style={{ paddingHorizontal: 20, paddingVertical: 24 }}>
+                <Text className="text-xl font-extrabold text-content-primary">바텀시트</Text>
                 <Text className="mt-2 text-sm text-content-secondary">
                   바깥 영역 탭 또는 아래로 스와이프하면 닫힙니다
                 </Text>
@@ -166,9 +134,7 @@ export default function HomeScreen() {
             )
           }
         >
-          <Text className="text-base text-center font-bold text-white">
-            바텀시트 열기
-          </Text>
+          <Text className="text-base text-center font-bold text-white">바텀시트 열기</Text>
         </Pressable>
       </ScrollView>
 

--- a/src/shared/config/tokens.ts
+++ b/src/shared/config/tokens.ts
@@ -80,6 +80,10 @@ export const semanticColors = {
   "heart-inactive": primitiveColors["warm-gray-300"],
   "tab-inactive": primitiveColors["warm-gray-250"],
 
+  // ── Overlay (토스트, 모달 배경) ──────────────────────────────────────────
+  "overlay-dark": "rgba(0, 0, 0, 0.6)", // 검정색 60% 투명도 — 토스트 배경색
+  "overlay-darker": "rgba(0, 0, 0, 0.8)", // 검정색 80% 투명도 — 진한 오버레이
+
   // ── Essentials ────────────────────────────────────────────────────────────
   white: primitiveColors["neutral-white"],
   black: "#000000",

--- a/src/shared/model/toast/index.ts
+++ b/src/shared/model/toast/index.ts
@@ -1,0 +1,4 @@
+// src/shared/model/toast/index.ts
+// Toast 모델 배럴 내보내기
+
+export { useToastStore, type ToastItem } from "./store";

--- a/src/shared/model/toast/index.ts
+++ b/src/shared/model/toast/index.ts
@@ -1,4 +1,4 @@
 // src/shared/model/toast/index.ts
 // Toast 모델 배럴 내보내기
 
-export { useToastStore, type ToastItem } from "./store";
+export { type ToastItem, useToastStore } from "./store";

--- a/src/shared/model/toast/store.ts
+++ b/src/shared/model/toast/store.ts
@@ -1,0 +1,44 @@
+// src/shared/model/toast/store.ts
+// Zustand 스토어: 토스트 메시지 상태 관리
+// 단일 토스트를 관리하며, 정해진 시간 후 자동으로 사라집니다.
+
+import { create } from "zustand";
+
+export interface ToastItem {
+  message: string;
+}
+
+interface ToastStore {
+  toast: ToastItem | null;
+  show: (message: string, duration?: number) => void;
+  hide: () => void;
+}
+
+let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toast: null,
+
+  show: (message, duration = 3000) => {
+    // Clear existing timeout if any
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    set({ toast: { message } });
+
+    // Auto-hide after duration
+    timeoutId = setTimeout(() => {
+      set({ toast: null });
+      timeoutId = null;
+    }, duration);
+  },
+
+  hide: () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    set({ toast: null });
+  },
+}));

--- a/src/shared/model/toast/store.ts
+++ b/src/shared/model/toast/store.ts
@@ -14,31 +14,33 @@ interface ToastStore {
   hide: () => void;
 }
 
-let timeoutId: ReturnType<typeof setTimeout> | null = null;
+export const useToastStore = create<ToastStore>((set) => {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-export const useToastStore = create<ToastStore>((set) => ({
-  toast: null,
+  return {
+    toast: null,
 
-  show: (message, duration = 3000) => {
-    // Clear existing timeout if any
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
+    show: (message, duration = 3000) => {
+      // Clear existing timeout if any
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
 
-    set({ toast: { message } });
+      set({ toast: { message } });
 
-    // Auto-hide after duration
-    timeoutId = setTimeout(() => {
+      // Auto-hide after duration
+      timeoutId = setTimeout(() => {
+        set({ toast: null });
+        timeoutId = null;
+      }, duration);
+    },
+
+    hide: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
       set({ toast: null });
-      timeoutId = null;
-    }, duration);
-  },
-
-  hide: () => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
-    set({ toast: null });
-  },
-}));
+    },
+  };
+});

--- a/src/shared/ui/toast/index.ts
+++ b/src/shared/ui/toast/index.ts
@@ -1,0 +1,4 @@
+// src/shared/ui/toast/index.ts
+// Toast UI 컴포넌트 배럴 내보내기
+
+export { ToastMessage } from "./toast-message";

--- a/src/shared/ui/toast/toast-message.tsx
+++ b/src/shared/ui/toast/toast-message.tsx
@@ -1,0 +1,73 @@
+// src/shared/ui/toast/toast-message.tsx
+// 토스트 메시지 공용 컴포넌트
+// 화면 위에 absolute로 고정되어 레이아웃에 영향을 주지 않습니다.
+// 나타날 때 페이드인, 사라질 때 페이드아웃 애니메이션이 적용됩니다.
+// ⚠️  모든 스타일은 src/shared/config/tokens.ts의 디자인 토큰에서 가져옵니다.
+
+import { useEffect, useRef, useState } from "react";
+import { Animated, Text } from "react-native";
+import { useToastStore, type ToastItem } from "@/shared/model/toast";
+import { tokens } from "@/shared/config/tokens";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { primitiveTypography } = require("@/shared/config/token-primitives.js");
+
+export function ToastMessage() {
+  const toast = useToastStore((s) => s.toast);
+  const [localToast, setLocalToast] = useState<ToastItem | null>(toast);
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (toast) {
+      setLocalToast(toast);
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+    } else {
+      Animated.timing(opacity, {
+        toValue: 0,
+        duration: 400,
+        useNativeDriver: true,
+      }).start(() => setLocalToast(null));
+    }
+  }, [toast, opacity]);
+
+  if (!localToast) return null;
+
+  return (
+    <Animated.View
+      style={{
+        opacity,
+        position: "absolute",
+        // 하단 위치: lg(24) + lg(24) + xl(32) + md(16) = 96px
+        bottom: tokens.spacing.lg + tokens.spacing.lg + tokens.spacing.xl + tokens.spacing.md,
+        alignSelf: "center",
+        width: "66%",
+        // 배경색: 검정색 60% 투명도
+        backgroundColor: tokens.color.black + "99",
+        // 테두리 반경: 2xl 토큰
+        borderRadius: tokens.radius["2xl"],
+        // 좌우 패딩: md(16px)
+        paddingHorizontal: tokens.spacing.md,
+        // 상하 패딩: sm(8px)
+        paddingVertical: tokens.spacing.sm,
+      }}
+      pointerEvents="none"
+    >
+      <Text
+        style={{
+          // 텍스트 색: white 토큰
+          color: tokens.color.white,
+          // 폰트 크기: 토큰 기반 (14px)
+          fontSize: primitiveTypography.sm.size,
+          // 폰트 가중치: 토큰 기반 (600)
+          fontWeight: primitiveTypography.sm.weight,
+          textAlign: "center",
+        }}
+      >
+        {localToast.message}
+      </Text>
+    </Animated.View>
+  );
+}

--- a/src/shared/ui/toast/toast-message.tsx
+++ b/src/shared/ui/toast/toast-message.tsx
@@ -42,8 +42,8 @@ export function ToastMessage() {
         bottom: tokens.spacing.lg + tokens.spacing.lg + tokens.spacing.xl + tokens.spacing.md,
         alignSelf: "center",
         width: "66%",
-        // 배경색: 검정색 60% 투명도
-        backgroundColor: `${tokens.color.black}99`,
+        // 배경색: 오버레이 다크 (검정색 60% 투명도)
+        backgroundColor: tokens.color["overlay-dark"],
         // 테두리 반경: 2xl 토큰
         borderRadius: tokens.radius["2xl"],
         // 좌우 패딩: md(16px)

--- a/src/shared/ui/toast/toast-message.tsx
+++ b/src/shared/ui/toast/toast-message.tsx
@@ -1,13 +1,11 @@
 // src/shared/ui/toast/toast-message.tsx
 // 토스트 메시지 공용 컴포넌트
-// 화면 위에 absolute로 고정되어 레이아웃에 영향을 주지 않습니다.
-// 나타날 때 페이드인, 사라질 때 페이드아웃 애니메이션이 적용됩니다.
-// ⚠️  모든 스타일은 src/shared/config/tokens.ts의 디자인 토큰에서 가져옵니다.
 
 import { useEffect, useRef, useState } from "react";
 import { Animated, Text } from "react-native";
-import { useToastStore, type ToastItem } from "@/shared/model/toast";
 import { tokens } from "@/shared/config/tokens";
+import { type ToastItem, useToastStore } from "@/shared/model/toast";
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { primitiveTypography } = require("@/shared/config/token-primitives.js");
 
@@ -45,7 +43,7 @@ export function ToastMessage() {
         alignSelf: "center",
         width: "66%",
         // 배경색: 검정색 60% 투명도
-        backgroundColor: tokens.color.black + "99",
+        backgroundColor: `${tokens.color.black}99`,
         // 테두리 반경: 2xl 토큰
         borderRadius: tokens.radius["2xl"],
         // 좌우 패딩: md(16px)


### PR DESCRIPTION
## 요약

- 재료 추가 및 스캔을 위한 토스트 메세지를 구현했습니다.

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #29 

## 작업 세부사항

- **토스트 메시지 상태 관리 스토어 구현**
  - `src/shared/model/toast/store.ts`: Zustand 기반 토스트 상태 관리
  - `show(message, duration)`: 메시지 표시 및 자동 종료 (기본은 3초)
  - `hide()`: 메시지 수동 종료

- **토스트 UI 컴포넌트 개발**
  - `src/shared/ui/toast/toast-message.tsx`: 토스트 메시지 컴포넌트
  - 화면 절대 위치(position: absolute)로 배치, 레이아웃 영향 제거
  - React Native `Animated` API로 페이드 인 / 페이드 아웃 형식으로 구현
 

## 참고사항
<img width="1440" height="2828" alt="image" src="https://github.com/user-attachments/assets/a1f50610-bd2f-49f3-8967-04944e9f2149" />
