### PR TITLE
[refactor/#40] FSD 레이어 분리 및 위젯화

### DIFF
--- a/src/entities/recipe/index.ts
+++ b/src/entities/recipe/index.ts
@@ -1,3 +1,5 @@
 // Public API for recipe entity model and UI.
+export type { CookingStep, Ingredient, Recipe } from "./model/recipe.types";
 export type { RecipeCardData, RecipeCardVariant } from "./model/types";
+export { useRecipeDetail } from "./model/useRecipeDetail";
 export { BannerFoodCard, DefaultFoodCard } from "./ui";

--- a/src/entities/recipe/model/useRecipeDetail.ts
+++ b/src/entities/recipe/model/useRecipeDetail.ts
@@ -1,0 +1,14 @@
+import type { Ingredient, Recipe } from "@/entities/recipe/model/recipe.types";
+
+/**
+ * 레시피 상세 데이터를 조회하고 재료를 분류하는 훅.
+ * 나중에 API 호출로 교체할 수 있도록 entities 레이어에서 관리합니다.
+ */
+export function useRecipeDetail(recipeId: string, recipesMap: Record<string, Recipe>) {
+  const recipe = recipesMap[recipeId] ?? null;
+
+  const ownedIngredients: Ingredient[] = recipe?.ingredients.filter((i) => i.owned) ?? [];
+  const missingIngredients: Ingredient[] = recipe?.ingredients.filter((i) => !i.owned) ?? [];
+
+  return { recipe, ownedIngredients, missingIngredients };
+}

--- a/src/features/search-recipe/hooks/useSearchRecipe.ts
+++ b/src/features/search-recipe/hooks/useSearchRecipe.ts
@@ -1,0 +1,34 @@
+import { useMemo, useState } from "react";
+
+import type { RecipeCardData } from "@/entities/recipe";
+import type { Category } from "@/shared/ui/CategoryFilter";
+
+/**
+ * 레시피 검색 & 카테고리 필터링 로직을 캡슐화하는 훅.
+ * 페이지에서 비즈니스 로직을 분리하여 features 레이어에서 관리합니다.
+ */
+export function useSearchRecipe(recipes: RecipeCardData[]) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
+
+  const filteredRecipes = useMemo(() => {
+    const lowercasedQuery = searchQuery.toLowerCase();
+
+    return recipes.filter((recipe) => {
+      const matchesCategory = selectedCategory === "전체" || recipe.category === selectedCategory;
+      const matchesSearch =
+        searchQuery === "" ||
+        recipe.title.toLowerCase().includes(lowercasedQuery) ||
+        recipe.missingIngredients.some((i) => i.toLowerCase().includes(lowercasedQuery));
+      return matchesCategory && matchesSearch;
+    });
+  }, [recipes, searchQuery, selectedCategory]);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    selectedCategory,
+    setSelectedCategory,
+    filteredRecipes,
+  };
+}

--- a/src/features/search-recipe/index.ts
+++ b/src/features/search-recipe/index.ts
@@ -1,0 +1,2 @@
+// Public API for search-recipe feature.
+export { useSearchRecipe } from "./hooks/useSearchRecipe";

--- a/src/pages/recipe-detail/ui/RecipeDetailPage.tsx
+++ b/src/pages/recipe-detail/ui/RecipeDetailPage.tsx
@@ -1,7 +1,8 @@
-import { Image, ScrollView, Text, View } from "react-native";
+import { ScrollView, Text, View } from "react-native";
+
 import type { Recipe } from "@/entities/recipe/model/recipe.types";
-import { tokens } from "@/shared/config/tokens";
-import { IconSymbol } from "@/shared/ui/icon-symbol";
+import { useRecipeDetail } from "@/entities/recipe/model/useRecipeDetail";
+import { RecipeHero, RecipeIngredients, RecipeMeta, RecipeSteps } from "@/widgets/RecipeDetail";
 
 // ────────────────────────────────────────────────────────
 // 더미 데이터 (API 연동 전 UI 확인용)
@@ -100,7 +101,7 @@ interface RecipeDetailPageProps {
 }
 
 export function RecipeDetailPage({ recipeId }: RecipeDetailPageProps) {
-  const recipe = DUMMY_RECIPES[recipeId];
+  const { recipe, ownedIngredients, missingIngredients } = useRecipeDetail(recipeId, DUMMY_RECIPES);
 
   if (!recipe) {
     return (
@@ -110,113 +111,26 @@ export function RecipeDetailPage({ recipeId }: RecipeDetailPageProps) {
     );
   }
 
-  const ownedIngredients = recipe.ingredients.filter((ingredient) => ingredient.owned);
-  const missingIngredients = recipe.ingredients.filter((ingredient) => !ingredient.owned);
-
   return (
     <ScrollView className="flex-1 bg-surface-app" showsVerticalScrollIndicator={false}>
       {/* 히어로 이미지 */}
-      <View className="relative aspect-[4/3]">
-        <Image source={{ uri: recipe.imageUrl }} className="h-full w-full" resizeMode="cover" />
-        {/* 태그 오버레이 */}
-        <View className="absolute bottom-4 left-4">
-          <Text className="text-xs text-white">{recipe.tags.map((t) => `#${t}`).join("  ")}</Text>
-          <Text className="mt-1 text-2xl font-extrabold text-white">{recipe.title}</Text>
-        </View>
-      </View>
+      <RecipeHero recipe={recipe} />
 
       <View className="px-screen py-6">
-        {/* 메타 정보 */}
-        <View className="flex-row items-center gap-4">
-          <View className="flex-row items-center gap-1">
-            <IconSymbol name="clock" size={14} color={tokens.color["content-secondary"]} />
-            <Text className="text-sm text-content-secondary">{recipe.cookingTime}분</Text>
-          </View>
-          <View className="flex-row items-center gap-1">
-            <IconSymbol name="person.2" size={14} color={tokens.color["content-secondary"]} />
-            <Text className="text-sm text-content-secondary">{recipe.servings}인분</Text>
-          </View>
-          <View className="flex-row items-center gap-1">
-            <IconSymbol name="flame" size={14} color={tokens.color["content-secondary"]} />
-            <Text className="text-sm text-content-secondary">{recipe.difficulty}</Text>
-          </View>
-        </View>
-
-        {/* 설명 */}
-        <Text className="mt-4 text-sm leading-5 text-content-dark">{recipe.description}</Text>
+        {/* 메타 정보 + 설명 */}
+        <RecipeMeta recipe={recipe} />
 
         {/* 구분선 */}
         <View className="my-6 h-px bg-stroke-default" />
 
         {/* 재료 */}
-        <Text className="text-lg font-bold text-content-primary">재료</Text>
-
-        {/* 보유 재료 */}
-        <View className="mt-3">
-          <Text className="text-sm font-semibold text-status-fresh">
-            ✓ 보유 재료 ({ownedIngredients.length})
-          </Text>
-          <View className="mt-2 flex-row flex-wrap gap-2">
-            {ownedIngredients.map((ing) => (
-              <View
-                key={ing.name}
-                className="rounded-tag border border-status-fresh-border bg-status-fresh-bg px-3 py-1"
-              >
-                <Text className="text-xs text-status-fresh">{ing.name}</Text>
-              </View>
-            ))}
-          </View>
-        </View>
-
-        {/* 부족한 재료 */}
-        {missingIngredients.length > 0 && (
-          <View className="mt-4">
-            <Text className="text-sm font-semibold text-status-expiring">
-              ✕ 부족한 재료 ({missingIngredients.length})
-            </Text>
-            <View className="mt-2 flex-row flex-wrap gap-2">
-              {missingIngredients.map((ing) => (
-                <View
-                  key={ing.name}
-                  className="rounded-tag border border-status-expiring-border bg-status-expiring-bg px-3 py-1"
-                >
-                  <Text className="text-xs text-status-expiring">{ing.name}</Text>
-                </View>
-              ))}
-            </View>
-          </View>
-        )}
+        <RecipeIngredients owned={ownedIngredients} missing={missingIngredients} />
 
         {/* 구분선 */}
         <View className="my-6 h-px bg-stroke-default" />
 
         {/* 조리 순서 */}
-        <Text className="text-lg font-bold text-content-primary">조리 순서</Text>
-        <View className="mt-4 gap-6">
-          {recipe.steps.map((s) => (
-            <View key={s.step} className="flex-row gap-3">
-              {/* 스텝 번호 */}
-              <View className="h-8 w-8 items-center justify-center rounded-full bg-primary">
-                <Text className="text-sm font-bold text-white">{s.step}</Text>
-              </View>
-              {/* 스텝 설명 */}
-              <View className="flex-1">
-                <Text className="text-sm leading-5 text-content-primary">{s.description}</Text>
-                <View className="mt-1 flex-row items-center gap-1">
-                  <IconSymbol name="clock" size={12} color={tokens.color["content-secondary"]} />
-                  <Text className="text-xs text-content-secondary">{s.duration}분</Text>
-                </View>
-                {s.imageUrl && (
-                  <Image
-                    source={{ uri: s.imageUrl }}
-                    className="mt-3 aspect-video w-full rounded-card"
-                    resizeMode="cover"
-                  />
-                )}
-              </View>
-            </View>
-          ))}
-        </View>
+        <RecipeSteps steps={recipe.steps} />
       </View>
     </ScrollView>
   );

--- a/src/pages/search/ui/SearchPage.tsx
+++ b/src/pages/search/ui/SearchPage.tsx
@@ -1,9 +1,8 @@
 import { useRouter } from "expo-router";
-import { useMemo, useState } from "react";
 import { ScrollView, Text, View } from "react-native";
 
 import type { RecipeCardData } from "@/entities/recipe";
-import type { Category } from "@/shared/ui/CategoryFilter";
+import { useSearchRecipe } from "@/features/search-recipe";
 import { CategoryFilter } from "@/shared/ui/CategoryFilter";
 import { SearchBar } from "@/shared/ui/SearchBar";
 import { RecipeList } from "@/widgets/RecipeList";
@@ -50,22 +49,8 @@ const DUMMY_RECIPES: RecipeCardData[] = [
 
 export function SearchPage() {
   const router = useRouter();
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState<Category>("전체");
-
-  // 간단한 클라이언트 사이드 필터링
-  const filteredRecipes = useMemo(() => {
-    const lowercasedQuery = searchQuery.toLowerCase();
-
-    return DUMMY_RECIPES.filter((recipe) => {
-      const matchesCategory = selectedCategory === "전체" || recipe.category === selectedCategory;
-      const matchesSearch =
-        searchQuery === "" ||
-        recipe.title.toLowerCase().includes(lowercasedQuery) ||
-        recipe.missingIngredients.some((i) => i.toLowerCase().includes(lowercasedQuery));
-      return matchesCategory && matchesSearch;
-    });
-  }, [searchQuery, selectedCategory]);
+  const { searchQuery, setSearchQuery, selectedCategory, setSelectedCategory, filteredRecipes } =
+    useSearchRecipe(DUMMY_RECIPES);
 
   const recipeCount = filteredRecipes.length;
 

--- a/src/shared/ui/SearchBar/SearchBar.tsx
+++ b/src/shared/ui/SearchBar/SearchBar.tsx
@@ -6,12 +6,15 @@ import { IconSymbol } from "@/shared/ui/icon-symbol";
 interface SearchBarProps {
   value: string;
   onChangeText: (text: string) => void;
+  /** 엔터(검색) 키를 눌렀을 때 실행될 콜백 */
+  onSubmit?: () => void;
   placeholder?: string;
 }
 
 export function SearchBar({
   value,
   onChangeText,
+  onSubmit,
   placeholder = "레시피 또는 재료 검색...",
 }: SearchBarProps) {
   return (
@@ -26,6 +29,7 @@ export function SearchBar({
         className="flex-1 text-base text-content-primary"
         value={value}
         onChangeText={onChangeText}
+        onSubmitEditing={onSubmit}
         placeholder={placeholder}
         placeholderTextColor={tokens.color["stroke-default"]}
         returnKeyType="search"

--- a/src/widgets/RecipeDetail/RecipeHero.tsx
+++ b/src/widgets/RecipeDetail/RecipeHero.tsx
@@ -1,0 +1,20 @@
+import { Image, Text, View } from "react-native";
+
+import type { Recipe } from "@/entities/recipe/model/recipe.types";
+
+interface RecipeHeroProps {
+  recipe: Recipe;
+}
+
+/** 레시피 상세 히어로 이미지 + 태그 오버레이 */
+export function RecipeHero({ recipe }: RecipeHeroProps) {
+  return (
+    <View className="relative aspect-[4/3]">
+      <Image source={{ uri: recipe.imageUrl }} className="h-full w-full" resizeMode="cover" />
+      <View className="absolute bottom-4 left-4">
+        <Text className="text-xs text-white">{recipe.tags.map((t) => `#${t}`).join("  ")}</Text>
+        <Text className="mt-1 text-2xl font-extrabold text-white">{recipe.title}</Text>
+      </View>
+    </View>
+  );
+}

--- a/src/widgets/RecipeDetail/RecipeIngredients.tsx
+++ b/src/widgets/RecipeDetail/RecipeIngredients.tsx
@@ -1,0 +1,53 @@
+import { Text, View } from "react-native";
+
+import type { Ingredient } from "@/entities/recipe/model/recipe.types";
+
+interface RecipeIngredientsProps {
+  owned: Ingredient[];
+  missing: Ingredient[];
+}
+
+/** 보유 재료 / 부족한 재료 섹션 */
+export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
+  return (
+    <View>
+      <Text className="text-lg font-bold text-content-primary">재료</Text>
+
+      {/* 보유 재료 */}
+      <View className="mt-3">
+        <Text className="text-sm font-semibold text-status-fresh">
+          ✓ 보유 재료 ({owned.length})
+        </Text>
+        <View className="mt-2 flex-row flex-wrap gap-2">
+          {owned.map((ing) => (
+            <View
+              key={ing.name}
+              className="rounded-tag border border-status-fresh-border bg-status-fresh-bg px-3 py-1"
+            >
+              <Text className="text-xs text-status-fresh">{ing.name}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {/* 부족한 재료 */}
+      {missing.length > 0 && (
+        <View className="mt-4">
+          <Text className="text-sm font-semibold text-status-expiring">
+            ✕ 부족한 재료 ({missing.length})
+          </Text>
+          <View className="mt-2 flex-row flex-wrap gap-2">
+            {missing.map((ing) => (
+              <View
+                key={ing.name}
+                className="rounded-tag border border-status-expiring-border bg-status-expiring-bg px-3 py-1"
+              >
+                <Text className="text-xs text-status-expiring">{ing.name}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/widgets/RecipeDetail/RecipeMeta.tsx
+++ b/src/widgets/RecipeDetail/RecipeMeta.tsx
@@ -1,0 +1,35 @@
+import { Text, View } from "react-native";
+
+import type { Recipe } from "@/entities/recipe/model/recipe.types";
+import { tokens } from "@/shared/config/tokens";
+import { IconSymbol } from "@/shared/ui/icon-symbol";
+
+interface RecipeMetaProps {
+  recipe: Recipe;
+}
+
+/** 조리시간 · 인분 · 난이도 메타 정보 + 설명 */
+export function RecipeMeta({ recipe }: RecipeMetaProps) {
+  return (
+    <View>
+      {/* 메타 정보 */}
+      <View className="flex-row items-center gap-4">
+        <View className="flex-row items-center gap-1">
+          <IconSymbol name="clock" size={14} color={tokens.color["content-secondary"]} />
+          <Text className="text-sm text-content-secondary">{recipe.cookingTime}분</Text>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <IconSymbol name="person.2" size={14} color={tokens.color["content-secondary"]} />
+          <Text className="text-sm text-content-secondary">{recipe.servings}인분</Text>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <IconSymbol name="flame" size={14} color={tokens.color["content-secondary"]} />
+          <Text className="text-sm text-content-secondary">{recipe.difficulty}</Text>
+        </View>
+      </View>
+
+      {/* 설명 */}
+      <Text className="mt-4 text-sm leading-5 text-content-dark">{recipe.description}</Text>
+    </View>
+  );
+}

--- a/src/widgets/RecipeDetail/RecipeSteps.tsx
+++ b/src/widgets/RecipeDetail/RecipeSteps.tsx
@@ -1,0 +1,43 @@
+import { Image, Text, View } from "react-native";
+
+import type { CookingStep } from "@/entities/recipe/model/recipe.types";
+import { tokens } from "@/shared/config/tokens";
+import { IconSymbol } from "@/shared/ui/icon-symbol";
+
+interface RecipeStepsProps {
+  steps: CookingStep[];
+}
+
+/** 조리 순서 섹션 */
+export function RecipeSteps({ steps }: RecipeStepsProps) {
+  return (
+    <View>
+      <Text className="text-lg font-bold text-content-primary">조리 순서</Text>
+      <View className="mt-4 gap-6">
+        {steps.map((s) => (
+          <View key={s.step} className="flex-row gap-3">
+            {/* 스텝 번호 */}
+            <View className="h-8 w-8 items-center justify-center rounded-full bg-primary">
+              <Text className="text-sm font-bold text-white">{s.step}</Text>
+            </View>
+            {/* 스텝 설명 */}
+            <View className="flex-1">
+              <Text className="text-sm leading-5 text-content-primary">{s.description}</Text>
+              <View className="mt-1 flex-row items-center gap-1">
+                <IconSymbol name="clock" size={12} color={tokens.color["content-secondary"]} />
+                <Text className="text-xs text-content-secondary">{s.duration}분</Text>
+              </View>
+              {s.imageUrl && (
+                <Image
+                  source={{ uri: s.imageUrl }}
+                  className="mt-3 aspect-video w-full rounded-card"
+                  resizeMode="cover"
+                />
+              )}
+            </View>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/widgets/RecipeDetail/index.ts
+++ b/src/widgets/RecipeDetail/index.ts
@@ -1,0 +1,5 @@
+// Public API for RecipeDetail widgets.
+export { RecipeHero } from "./RecipeHero";
+export { RecipeIngredients } from "./RecipeIngredients";
+export { RecipeMeta } from "./RecipeMeta";
+export { RecipeSteps } from "./RecipeSteps";


### PR DESCRIPTION
## 요약

지난 #33번 이슈의 @chunjaemin 의 피드백을 반영하여 FSD 레이어 분리 및 위젯화를 수행하였습니다.

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #40  
- Closes #33

## 작업 세부사항

- SearchPage의 검색/필터링 로직을 features/search-recipe/hooks/useSearchRecipe.ts 훅으로 분리
- SearchBar 공용 컴포넌트에 onSubmit 콜백 추가 (엔터 키 검색 지원)
- RecipeDetailPage의 데이터 로직을 entities/recipe/model/useRecipeDetail.ts 훅으로 분리
- RecipeDetailPage의 UI 섹션을 widgets로 분리 (RecipeHero, RecipeMeta, RecipeIngredients, - RecipeSteps)
- entities/recipe/index.ts 에 새 타입 및 훅 export 추가

## 참고사항
모든 변경은 리펙터링이고, UI/동작 변경은 없습니다.