### PR TITLE
[chore/#82] react-native-svg 버전 업그레이드

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
-        "react-native-svg": "15.12.1",
+        "react-native-svg": "^15.15.4",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
         "zustand": "^5.0.11"
@@ -12261,9 +12261,9 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "15.12.1",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
-      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "version": "15.15.4",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.4.tgz",
+      "integrity": "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
     "react-native-worklets": "0.5.1",
     "zustand": "^5.0.11"
   },
+  "expo": {
+    "install": {
+      "exclude": ["react-native-svg"]
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",
     "@types/react": "~19.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-svg": "15.12.1",
+    "react-native-svg": "^15.15.4",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
     "zustand": "^5.0.11"


### PR DESCRIPTION
## 요약

- react-native-svg를 최신버전으로 업그레이드 하였습니다. 
- expo-doctor 검사 대상에서 react-native-svg를 제거하였습니다. 

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #82 

## 작업 세부사항

- react-native-svg 15.15.14로 업그레이드 
- package.json의 expo.install.exclude 항목에 react-native-svg추가
