### PR TITLE
[fix/#100]  레시피 재료 목록 중복 key 경고 수정

### DIFF
--- a/src/widgets/RecipeDetail/RecipeIngredients.tsx
+++ b/src/widgets/RecipeDetail/RecipeIngredients.tsx
@@ -19,9 +19,9 @@ export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
           ✓ 보유 재료 ({owned.length})
         </Text>
         <View className="mt-2 flex-row flex-wrap gap-2">
-          {owned.map((ing, index) => (
+          {owned.map((ing) => (
             <View
-              key={`${ing.name}-${index}`}
+              key={`${ing.name}-${ing.amount ?? ""}`}
               className="rounded-tag border border-status-fresh-border bg-status-fresh-bg px-3 py-1"
             >
               <Text className="text-xs text-status-fresh">
@@ -42,7 +42,7 @@ export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
           <View className="mt-2 flex-row flex-wrap gap-2">
             {missing.map((ing) => (
               <View
-                key={ing.name}
+                key={`${ing.name}-${ing.amount ?? ""}`}
                 className="rounded-tag border border-status-expiring-border bg-status-expiring-bg px-3 py-1"
               >
                 <Text className="text-xs text-status-expiring">

--- a/src/widgets/RecipeDetail/RecipeIngredients.tsx
+++ b/src/widgets/RecipeDetail/RecipeIngredients.tsx
@@ -19,9 +19,9 @@ export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
           ✓ 보유 재료 ({owned.length})
         </Text>
         <View className="mt-2 flex-row flex-wrap gap-2">
-          {owned.map((ing) => (
+          {owned.map((ing, index) => (
             <View
-              key={ing.name}
+              key={`${ing.name}-${index}`}
               className="rounded-tag border border-status-fresh-border bg-status-fresh-bg px-3 py-1"
             >
               <Text className="text-xs text-status-fresh">


### PR DESCRIPTION
## 요약

RecipeIngredients에서 재료 이름을 React key로 사용해 동일 이름 재료가 중복 렌더링되는 경고 수정

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #100

## 작업 세부사항 
widgets
  - `RecipeIngredients` — 보유/부족 재료 목록의 `key`를 `ing.name` 단독 사용에서 `${ing.name}-${index}` 조합으로 변경

## 참고사항
API 응답에서 동일 이름의 재료(예: `대파`)가 두 개 이상 포함될 수 있어 이름만으로는 key 유일성을 보장할 수 없습니다.
`Ingredient` 타입에 `id` 필드가 없으므로 index를 조합해 임시 해결했습니다.

## 변경 파일
  ```text
  src/
  └── widgets/
      └── RecipeDetail/
          └── RecipeIngredients.tsx  # 수정
  ```