### PR TITLE
[feat/#103] 스캔페이지 API 연동 완료

### DIFF
--- a/src/features/scan-camera/api/post-scan-image.ts
+++ b/src/features/scan-camera/api/post-scan-image.ts
@@ -1,21 +1,37 @@
 // src/features/scan-camera/api/post-scan-image.ts
 // 캡처한 이미지를 서버에 전송하여 식재료를 인식하는 API 함수.
-// 현재는 mock 응답을 반환하며, 실제 엔드포인트 연결 시 FormData 전송으로 교체한다.
+// POST /fridge/ocr-auto-place — multipart/form-data 로 이미지를 전송하고 인식된 재료 목록을 반환한다.
+
+import type { IngredientRes } from "@/entities/fridge";
+import { apiRequest } from "@/shared/api";
 
 export type ScanImageResult = {
-  ingredients: string[];
+  saved: IngredientRes[];
 };
 
-export async function postScanImage(_imageUri: string): Promise<ScanImageResult> {
-  // TODO: 실제 API 연결 시 아래 코드로 교체
-  // const formData = new FormData();
-  // formData.append("image", { uri: imageUri, name: "scan.jpg", type: "image/jpeg" } as unknown as Blob);
-  // const response = await fetch("https://api.example.com/scan", { method: "POST", body: formData });
-  // return response.json();
+type OcrRes = {
+  saved: IngredientRes[];
+};
 
-  await new Promise((resolve) => setTimeout(resolve, 1500));
+export async function postScanImage(imageUri: string): Promise<ScanImageResult> {
+  if (__DEV__) console.log("[POST /fridge/ocr-auto-place] request", imageUri);
 
-  return {
-    ingredients: ["당근", "양파", "달걀", "두부", "시금치"],
-  };
+  const formData = new FormData();
+  formData.append("image", {
+    uri: imageUri,
+    name: "scan.jpg",
+    type: "image/jpeg",
+  } as unknown as Blob);
+
+  const data = await apiRequest<OcrRes>("/fridge/ocr-auto-place", {
+    method: "POST",
+    body: formData,
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  if (__DEV__) console.log("[POST /fridge/ocr-auto-place] response", JSON.stringify(data, null, 2));
+
+  return { saved: data.saved ?? [] };
 }

--- a/src/features/scan-camera/model/useScanCamera.ts
+++ b/src/features/scan-camera/model/useScanCamera.ts
@@ -7,6 +7,7 @@ import type { CameraView } from "expo-camera";
 import { useCameraPermissions } from "expo-camera";
 import * as ImagePicker from "expo-image-picker";
 import { useCallback, useRef, useState } from "react";
+import { Alert } from "react-native";
 import { postScanImage } from "../api/post-scan-image";
 
 export type ScanMode = "camera" | "preview" | "submitting";
@@ -24,10 +25,16 @@ export function useScanCamera({ onSubmitSuccess }: UseScanCameraOptions) {
   const { mutate: submitImage, isPending } = useMutation({
     mutationFn: (uri: string) => postScanImage(uri),
     onSuccess: (data) => {
-      onSubmitSuccess(data.ingredients);
+      const ingredientNames = data.saved.map((item) => item.name);
+      onSubmitSuccess(ingredientNames);
     },
     onError: () => {
       setMode("preview");
+      Alert.alert(
+        "분석 실패",
+        "식재료 인식에 실패했습니다. 사진을 다시 찍거나 잠시 후 다시 시도해 주세요.",
+        [{ text: "확인" }],
+      );
     },
   });
 

--- a/src/pages/scan-result/ui/ScanResultPage.tsx
+++ b/src/pages/scan-result/ui/ScanResultPage.tsx
@@ -1,16 +1,39 @@
 // src/pages/scan-result/ui/ScanResultPage.tsx
 // 스캔 결과 화면 페이지 컴포넌트.
-// 서버에서 인식된 식재료 목록을 표시하며, [다시 스캔] 버튼으로 돌아갈 수 있다.
+// 서버에서 인식된 식재료 목록을 표시하며, [냉장고에 추가] 버튼으로 일괄 추가하거나 [다시 스캔] 버튼으로 돌아갈 수 있다.
 
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from "react-native";
+import { useAddFridgeItem } from "@/features/add-fridge-item";
 import { PageLayout } from "@/shared/ui/page-layout";
+
+const DEFAULT_QUANTITY = "1개";
 
 export function ScanResultPage() {
   const router = useRouter();
   const { ingredients: rawIngredients } = useLocalSearchParams<{ ingredients: string }>();
 
   const ingredients: string[] = rawIngredients ? JSON.parse(rawIngredients) : [];
+
+  const { mutateAsync: addFridgeItem, isPending } = useAddFridgeItem();
+
+  const handleAddAll = async () => {
+    if (ingredients.length === 0) return;
+
+    try {
+      await Promise.all(
+        ingredients.map((name) => addFridgeItem({ name, quantity: DEFAULT_QUANTITY })),
+      );
+      Alert.alert("추가 완료", "식재료가 냉장고에 추가되었습니다.", [
+        {
+          text: "확인",
+          onPress: () => router.replace("/(protected)/(tabs)/inventory"),
+        },
+      ]);
+    } catch {
+      Alert.alert("추가 실패", "일부 식재료를 추가하지 못했습니다. 다시 시도해 주세요.");
+    }
+  };
 
   return (
     <PageLayout>
@@ -44,14 +67,28 @@ export function ScanResultPage() {
       </ScrollView>
 
       {/* 하단 버튼 */}
-      <View className="px-screen pb-8 pt-4">
+      <View className="px-screen pb-8 pt-4 gap-3">
+        <Pressable
+          onPress={handleAddAll}
+          disabled={isPending || ingredients.length === 0}
+          className="bg-primary rounded-xl py-4 items-center justify-center active:opacity-70 disabled:opacity-50"
+          accessibilityRole="button"
+          accessibilityLabel="냉장고에 추가"
+        >
+          {isPending ? (
+            <ActivityIndicator color="#ffffff" />
+          ) : (
+            <Text className="text-white font-semibold text-base">냉장고에 추가</Text>
+          )}
+        </Pressable>
         <Pressable
           onPress={() => router.back()}
-          className="bg-primary rounded-xl py-4 items-center justify-center active:opacity-70"
+          disabled={isPending}
+          className="bg-surface-card rounded-xl py-4 items-center justify-center active:opacity-70 disabled:opacity-50 border border-stroke-default"
           accessibilityRole="button"
           accessibilityLabel="다시 스캔하기"
         >
-          <Text className="text-white font-semibold text-base">다시 스캔하기</Text>
+          <Text className="text-content-primary font-semibold text-base">다시 스캔하기</Text>
         </Pressable>
       </View>
     </PageLayout>


### PR DESCRIPTION
## 요약                                                                                                                                
스캔페이지 API 연동 완료                                                                                                

## 관련 이슈
  
  - Closes #103

  ## 작업 세부사항

  ### 1. postScanImage API 연동
  - Mock 응답에서 실제 서버 API로 변경
  - POST `/fridge/ocr-auto-place` 엔드포인트 연결
  - FormData로 이미지 multipart/form-data 형식 전송
  - 서버 응답 타입 맞춤 (IngredientRes[] 파싱)

  ### 2. useScanCamera 훅 개선
  - API 응답 처리: `data.saved.map(item => item.name)` 으로 재료명 추출
  - 에러 핸들링 추가: 인식 실패 시 Alert 표시
  - preview 모드로 복귀하여 재촬영 가능하도록 개선

  ### 3. ScanResultPage 기능 구현
  - `useAddFridgeItem` 훅 연동
  - "냉장고에 추가" 버튼 추가
  - Promise.all로 모든 재료를 동시에 DB에 추가
  - 완료 후 inventory 탭으로 자동 이동
  - 실패 시 Alert로 사용자 안내
