### PR TITLE
[fix/#107] 로그인 에러 해결[1/2]

### DIFF
--- a/src/features/kakao-login/api/kakao-auth.ts
+++ b/src/features/kakao-login/api/kakao-auth.ts
@@ -36,12 +36,9 @@ export async function kakaoLogin(): Promise<KakaoLoginResponse> {
     }
 
     // 2. Exchange with backend
-    const data = await apiPost<KakaoLoginResponse>(
-      "/auth/login/kakao",
-      {
-        accessToken: result.accessToken,
-      },
-    );
+    const data = await apiPost<KakaoLoginResponse>("/auth/login/kakao", {
+      accessToken: result.accessToken,
+    });
 
     return data;
   } catch (error) {

--- a/src/features/kakao-login/api/kakao-auth.ts
+++ b/src/features/kakao-login/api/kakao-auth.ts
@@ -36,13 +36,14 @@ export async function kakaoLogin(): Promise<KakaoLoginResponse> {
     }
 
     // 2. Exchange with backend
-    const data = await apiPost<{ message: string; result: KakaoLoginResponse }>(
+    const data = await apiPost<KakaoLoginResponse>(
       "/auth/login/kakao",
       {
         accessToken: result.accessToken,
       },
     );
-    return data.result;
+
+    return data;
   } catch (error) {
     // 카카오 세션 정리 후 사용자 친화적인 에러로 재throw
     await logout().catch(() => {});


### PR DESCRIPTION
## 요약
- 카카오 로그인 API 응답 타입 수정                                                                                                                                            
- "cannot read user properties" 에러 해결
                                                                                                                                         
  ## 관련 이슈
  
  - Closes #107

  ## 작업 세부사항

  ### kakao-auth.ts 타입 개선
  - **변경 전:** 백엔드 응답 타입을 `{ message: string; result: KakaoLoginResponse }` 로 설정
    ```typescript
    const data = await apiPost<{ message: string; result: KakaoLoginResponse }>(...)
    return data.result;
    
  - 변경 후: 응답 타입 개선 KakaoLoginResponse 로 단순화
    ```typescript  
     const data = await apiPost<KakaoLoginResponse>(...)
     return data;

  효과:
  - 백엔드 응답이 직접 { user, token } 구조로 반환되므로 불필요한 nesting 제거
  - data.result 접근 시도로 인한 undefined 에러 방지
  - 타입 안전성 개선
