### PR TITLE
[feat/#109] 마이페이지 알레르기 기능 추가 [2/2]

### DIFF
--- a/src/features/kakao-login/api/kakao-auth.ts
+++ b/src/features/kakao-login/api/kakao-auth.ts
@@ -36,12 +36,9 @@ export async function kakaoLogin(): Promise<KakaoLoginResponse> {
     }
 
     // 2. Exchange with backend
-    const data = await apiPost<KakaoLoginResponse>(
-      "/auth/login/kakao",
-      {
-        accessToken: result.accessToken,
-      },
-    );
+    const data = await apiPost<KakaoLoginResponse>("/auth/login/kakao", {
+      accessToken: result.accessToken,
+    });
 
     return data;
   } catch (error) {

--- a/src/features/kakao-login/api/kakao-auth.ts
+++ b/src/features/kakao-login/api/kakao-auth.ts
@@ -36,13 +36,14 @@ export async function kakaoLogin(): Promise<KakaoLoginResponse> {
     }
 
     // 2. Exchange with backend
-    const data = await apiPost<{ message: string; result: KakaoLoginResponse }>(
+    const data = await apiPost<KakaoLoginResponse>(
       "/auth/login/kakao",
       {
         accessToken: result.accessToken,
       },
     );
-    return data.result;
+
+    return data;
   } catch (error) {
     // 카카오 세션 정리 후 사용자 친화적인 에러로 재throw
     await logout().catch(() => {});

--- a/src/features/user-preferences/api/use-preferences-mutations.ts
+++ b/src/features/user-preferences/api/use-preferences-mutations.ts
@@ -7,10 +7,9 @@ import { updateUserPreferences } from "./update-preferences";
 // ─── useAddAllergy ────────────────────────────────────────────────────────────
 
 export function useAddAllergy() {
-  const { allergies, setAllergies, dislikedIngredients } = usePreferencesStore();
-
   return useMutation({
     mutationFn: async (newAllergy: string) => {
+      const { allergies, dislikedIngredients } = usePreferencesStore.getState();
       const trimmed = newAllergy.trim().slice(0, 30);
       if (!trimmed) throw new Error("알레르기명을 입력해주세요");
       if (allergies.includes(trimmed)) throw new Error("이미 등록된 알레르기입니다");
@@ -23,7 +22,7 @@ export function useAddAllergy() {
       return result;
     },
     onSuccess: (result) => {
-      setAllergies(result.allergies);
+      usePreferencesStore.getState().setAllergies(result.allergies);
     },
   });
 }
@@ -31,10 +30,9 @@ export function useAddAllergy() {
 // ─── useRemoveAllergy ─────────────────────────────────────────────────────────
 
 export function useRemoveAllergy() {
-  const { allergies, setAllergies, dislikedIngredients } = usePreferencesStore();
-
   return useMutation({
     mutationFn: async (allergyToRemove: string) => {
+      const { allergies, dislikedIngredients } = usePreferencesStore.getState();
       const updated = allergies.filter((a) => a !== allergyToRemove);
       const result = await updateUserPreferences({
         allergies: updated,
@@ -43,7 +41,7 @@ export function useRemoveAllergy() {
       return result;
     },
     onSuccess: (result) => {
-      setAllergies(result.allergies);
+      usePreferencesStore.getState().setAllergies(result.allergies);
     },
   });
 }

--- a/src/pages/mypage/ui/MyPage.tsx
+++ b/src/pages/mypage/ui/MyPage.tsx
@@ -18,7 +18,7 @@ export function MyPage() {
   const { logout } = useKakaoLogin();
   const { data: userProfile, isLoading, isError } = useUserProfile();
   const { data: scraps = [] } = useScraps();
-  const { allergies, isSheetOpen, closeSheet, setAllergies } = usePreferencesStore();
+  const { allergies, isSheetOpen, openSheet, closeSheet, setAllergies } = usePreferencesStore();
 
   useEffect(() => {
     if (userProfile?.allergies) {
@@ -26,7 +26,7 @@ export function MyPage() {
     }
   }, [userProfile?.allergies, setAllergies]);
 
-  const _allergySubtitle =
+  const allergySubtitle =
     allergies.length > 0 ? `${allergies.length}개 설정됨` : "설정된 알레르기가 없어요";
 
   return (
@@ -81,12 +81,8 @@ export function MyPage() {
           <SettingsListRow
             icon="shield"
             title="알레르기 설정"
-            subtitle={
-              !userProfile || userProfile.allergies.length === 0
-                ? "설정된 알레르기가 없어요"
-                : `${userProfile.allergies.length}개 설정됨`
-            }
-            onPress={ALERT_STUB}
+            subtitle={allergySubtitle}
+            onPress={openSheet}
           />
         </View>
 


### PR DESCRIPTION
 ## 의존성 
이 PR은 #107에 의존성이 있습니다. 107먼저 merge한 이후에 merge부탁드립니다

 ## 요약

  - 마이페이지에서 사용자 알레르기 설정을 추가, 수정, 삭제할 수 있는 기능 구현
  - 알레르기 CRUD API를 `user-preferences` feature에 연동하여 실시간 동기화
  - 알레르기 설정 UI 컴포넌트(`AllergySettingsSheet`) 추가 및 상태 관리 통합

  ## 관련 이슈

  - Closes #109

  ## 작업 세부사항

  - **user-preferences feature 추가**
    - `src/features/user-preferences/api/`: 알레르기 설정 API 엔드포인트 연동
    - `src/features/user-preferences/model/`: Zustand store로 알레르기 상태 관리
    - `src/features/user-preferences/ui/`: AllergySettingsSheet 컴포넌트로 UI 제공

  - **알레르기 설정 시트 구현**
    - 태그 기반 입력으로 알레르기 추가/삭제
    - 실시간 API 동기화로 백엔드 즉시 반영
    - 오류 처리 및 로딩 상태 관리
