### PR TITLE
[fix/#111] 좋아요한 레시피 페이지 카드 표시 안되는 문제 해결

### DIFF
--- a/src/pages/liked-recipes/ui/LikedRecipesPage.tsx
+++ b/src/pages/liked-recipes/ui/LikedRecipesPage.tsx
@@ -1,5 +1,6 @@
 import { router } from "expo-router";
-import { ActivityIndicator, SafeAreaView, ScrollView, Text, View } from "react-native";
+import { ActivityIndicator, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import type { RecipeCardData } from "@/entities/recipe";
 import { useScraps } from "@/features/liked-recipes";
@@ -15,7 +16,7 @@ export function LikedRecipesPage() {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-surface-app">
+    <SafeAreaView className="flex-1 bg-surface-app" edges={["top"]}>
       {/* 헤더 */}
       <View className="flex-row items-center px-screen py-4">
         <BackButton onPress={() => router.back()} variant="light" />
@@ -30,7 +31,7 @@ export function LikedRecipesPage() {
       {/* 레시피 그리드 */}
       <ScrollView
         className="flex-1"
-        contentContainerClassName="px-screen pb-10"
+        contentContainerStyle={{ paddingHorizontal: tokens.spacing.screen, paddingBottom: 40 }}
         showsVerticalScrollIndicator={false}
       >
         {isLoading ? (


### PR DESCRIPTION
  ## 요약

  - 좋아요한 레시피 페이지에서 카드가 표시되지 않는 문제 해결

  ## 관련 이슈

Closes #111 

  ## 작업 세부사항

  - SafeAreaView import를 react-native-safe-area-context에서 가져오기
  - SafeAreaView edges={["top"]} prop 추가로 상단만 safe area 처리
  - ScrollView contentContainerStyle로 padding을 명시적으로 설정
  
  ## 참고사항
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/0b2043f6-06fe-4f18-9ca3-7abefc2b059f" />
