### PR TITLE
[feat/#112] 레시피 카드 보유 재료 칩 표시 및 매칭률 뱃지 색상 개선

### DIFF
--- a/src/entities/recipe/model/recipe-mappers.ts
+++ b/src/entities/recipe/model/recipe-mappers.ts
@@ -6,7 +6,8 @@ import type { RecipeCardData } from "./types";
 
 export function toRecipeCardData(dto: RecipeDTO): RecipeCardData {
   const missingSet = new Set(dto.missingIngredients);
-  const _matched = dto.ingredients.map((i) => i.name).filter((name) => !missingSet.has(name));
+  const allNames = dto.ingredients.map((i) => i.name);
+  const matched = allNames.filter((name) => !missingSet.has(name));
 
   return {
     recipeId: dto.recipeId,
@@ -21,6 +22,7 @@ export function toRecipeCardData(dto: RecipeDTO): RecipeCardData {
               100,
           )
         : 0,
+    allIngredients: matched.length > 0 ? matched : allNames,
     missingIngredients: dto.missingIngredients,
     cookTime: dto.cookTime,
     difficulty: dto.difficulty,

--- a/src/entities/recipe/ui/parts/BannerCardContent.tsx
+++ b/src/entities/recipe/ui/parts/BannerCardContent.tsx
@@ -33,7 +33,6 @@ export function BannerCardContent({
         <IngredientChipsRow
           labels={chipDisplay.visibleLabels}
           overflowCount={chipDisplay.totalOverflow}
-          showEnoughChip={chipDisplay.showEnoughChip}
           variant="banner"
         />
       </View>

--- a/src/entities/recipe/ui/parts/DefaultCardContent.tsx
+++ b/src/entities/recipe/ui/parts/DefaultCardContent.tsx
@@ -26,7 +26,6 @@ export function DefaultCardContent({
         <IngredientChipsRow
           labels={safeLabels}
           overflowCount={safeOverflowCount}
-          showEnoughChip={safeLabels.length === 0}
           variant="default"
         />
       </View>

--- a/src/entities/recipe/ui/parts/IngredientChipsRow.tsx
+++ b/src/entities/recipe/ui/parts/IngredientChipsRow.tsx
@@ -18,8 +18,8 @@ export function IngredientChipsRow({ labels, overflowCount, variant }: Ingredien
 
   return (
     <>
-      {labels.map((label) => (
-        <View key={label} className={chipContainerClassName}>
+      {labels.map((label, index) => (
+        <View key={`${index}-${label}`} className={chipContainerClassName}>
           <Text className="text-sm font-semibold text-content-dark" numberOfLines={1}>
             {label}
           </Text>

--- a/src/entities/recipe/ui/parts/IngredientChipsRow.tsx
+++ b/src/entities/recipe/ui/parts/IngredientChipsRow.tsx
@@ -18,8 +18,8 @@ export function IngredientChipsRow({ labels, overflowCount, variant }: Ingredien
 
   return (
     <>
-      {labels.map((label, index) => (
-        <View key={`${index}-${label}`} className={chipContainerClassName}>
+      {labels.map((label) => (
+        <View key={label} className={chipContainerClassName}>
           <Text className="text-sm font-semibold text-content-dark" numberOfLines={1}>
             {label}
           </Text>

--- a/src/entities/recipe/ui/parts/IngredientChipsRow.tsx
+++ b/src/entities/recipe/ui/parts/IngredientChipsRow.tsx
@@ -4,23 +4,14 @@ import { Text, View } from "react-native";
 interface IngredientChipsRowProps {
   labels: string[];
   overflowCount: number;
-  showEnoughChip: boolean;
   variant: "banner" | "default";
 }
 
-export function IngredientChipsRow({
-  labels,
-  overflowCount,
-  showEnoughChip,
-  variant,
-}: IngredientChipsRowProps) {
+export function IngredientChipsRow({ labels, overflowCount, variant }: IngredientChipsRowProps) {
   const isBanner = variant === "banner";
   const chipContainerClassName = isBanner
     ? "max-w-[90px] rounded-full bg-surface-card px-3 py-1.5"
     : "max-w-[96px] rounded-full bg-surface-card/95 px-3 py-1.5";
-  const enoughChipClassName = isBanner
-    ? "rounded-full bg-status-fresh-bg px-3 py-1.5"
-    : "rounded-full bg-status-fresh-bg/95 px-3 py-1.5";
   const overflowChipClassName = isBanner
     ? "rounded-full bg-surface-section px-3 py-1.5"
     : "rounded-full bg-surface-section/95 px-3 py-1.5";
@@ -34,12 +25,6 @@ export function IngredientChipsRow({
           </Text>
         </View>
       ))}
-
-      {showEnoughChip ? (
-        <View className={enoughChipClassName}>
-          <Text className="text-sm font-semibold text-status-fresh">재료 충분</Text>
-        </View>
-      ) : null}
 
       {overflowCount > 0 ? (
         <View className={overflowChipClassName}>

--- a/src/entities/recipe/ui/parts/MatchRateBadge.tsx
+++ b/src/entities/recipe/ui/parts/MatchRateBadge.tsx
@@ -3,7 +3,6 @@
 import { Text, View } from "react-native";
 
 const HIGH_MATCH_THRESHOLD = 80;
-const MID_MATCH_THRESHOLD = 50;
 
 interface MatchRateBadgeProps {
   matchRate?: number;
@@ -11,7 +10,6 @@ interface MatchRateBadgeProps {
 
 function getMatchRateStyle(rate: number): string {
   if (rate >= HIGH_MATCH_THRESHOLD) return "bg-status-fresh";
-  if (rate >= MID_MATCH_THRESHOLD) return "bg-status-soon";
   return "bg-black/70";
 }
 

--- a/src/features/home-feed/api/get-fridge-recipes.ts
+++ b/src/features/home-feed/api/get-fridge-recipes.ts
@@ -30,10 +30,15 @@ interface FridgeRecipesRes {
 
 // Mapper: RecipeDTO → RecipeCardData
 export function toRecipeCardData(dto: RecipeDTO): RecipeCardData {
+  const missingSet = new Set(dto.missingIngredients);
+  const allNames = dto.ingredients.map((i) => i.name);
+  const matched = allNames.filter((name) => !missingSet.has(name));
+
   return {
     recipeId: dto.recipeId,
     title: dto.title,
     mainImage: dto.mainImage,
+    allIngredients: matched.length > 0 ? matched : allNames,
     missingIngredients: dto.missingIngredients,
     cookTime: dto.cookTime,
     difficulty: dto.difficulty,

--- a/src/shared/ui/IngredientTagInput/IngredientTagInput.tsx
+++ b/src/shared/ui/IngredientTagInput/IngredientTagInput.tsx
@@ -22,10 +22,8 @@ interface IngredientTagInputProps {
 }
 
 const INCLUDE_BG = tokens.color["tag-bg"];
-const INCLUDE_BORDER = tokens.color["tag-border"];
 const INCLUDE_TEXT = tokens.color["tag-text"];
 const EXCLUDE_BG = tokens.color["status-expiring-bg"];
-const EXCLUDE_BORDER = tokens.color["status-expiring-border"];
 const EXCLUDE_TEXT = tokens.color["status-expiring"];
 
 export function IngredientTagInput({
@@ -62,7 +60,6 @@ export function IngredientTagInput({
         {tags.map((tag) => {
           const isExclude = tag.type === "exclude";
           const bg = isExclude ? EXCLUDE_BG : INCLUDE_BG;
-          const border = isExclude ? EXCLUDE_BORDER : INCLUDE_BORDER;
           const color = isExclude ? EXCLUDE_TEXT : INCLUDE_TEXT;
           return (
             <View

--- a/src/shared/ui/IngredientTagInput/IngredientTagInput.tsx
+++ b/src/shared/ui/IngredientTagInput/IngredientTagInput.tsx
@@ -68,11 +68,7 @@ export function IngredientTagInput({
             <View
               key={tag.id}
               className="flex-row items-center gap-1 rounded-full px-3 py-1"
-              style={
-                isExclude
-                  ? { backgroundColor: bg, borderWidth: 1, borderColor: border }
-                  : { backgroundColor: bg }
-              }
+              style={{ backgroundColor: bg }}
             >
               {isExclude && <Text style={{ fontSize: 12, fontWeight: "700", color }}>−</Text>}
               <Text style={{ fontSize: 13, fontWeight: "500", color }}>{tag.label}</Text>

--- a/src/widgets/RecipeDetail/RecipeIngredients.tsx
+++ b/src/widgets/RecipeDetail/RecipeIngredients.tsx
@@ -19,11 +19,8 @@ export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
           ✓ 필요한 재료 ({owned.length})
         </Text>
         <View className="mt-2 flex-row flex-wrap gap-2">
-          {owned.map((ing, index) => (
-            <View
-              key={`${index}-${ing.name}`}
-              className="rounded-tag bg-status-fresh-bg px-3 py-1"
-            >
+          {owned.map((ing) => (
+            <View key={ing.name} className="rounded-tag bg-status-fresh-bg px-3 py-1">
               <Text className="text-xs text-status-fresh">
                 {ing.name}
                 {ing.amount ? ` ${ing.amount}` : ""}
@@ -40,9 +37,9 @@ export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
             ✕ 부족한 재료 ({missing.length})
           </Text>
           <View className="mt-2 flex-row flex-wrap gap-2">
-            {missing.map((ing, index) => (
+            {missing.map((ing) => (
               <View
-                key={`${index}-${ing.name}`}
+                key={ing.name}
                 className="rounded-tag border border-status-expiring-border bg-status-expiring-bg px-3 py-1"
               >
                 <Text className="text-xs text-status-expiring">

--- a/src/widgets/RecipeDetail/RecipeIngredients.tsx
+++ b/src/widgets/RecipeDetail/RecipeIngredients.tsx
@@ -19,9 +19,9 @@ export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
           ✓ 필요한 재료 ({owned.length})
         </Text>
         <View className="mt-2 flex-row flex-wrap gap-2">
-          {owned.map((ing) => (
+          {owned.map((ing, index) => (
             <View
-              key={`${ing.name}-${ing.amount ?? ""}`}
+              key={`${index}-${ing.name}`}
               className="rounded-tag bg-status-fresh-bg px-3 py-1"
             >
               <Text className="text-xs text-status-fresh">
@@ -40,9 +40,9 @@ export function RecipeIngredients({ owned, missing }: RecipeIngredientsProps) {
             ✕ 부족한 재료 ({missing.length})
           </Text>
           <View className="mt-2 flex-row flex-wrap gap-2">
-            {missing.map((ing) => (
+            {missing.map((ing, index) => (
               <View
-                key={`${ing.name}-${ing.amount ?? ""}`}
+                key={`${index}-${ing.name}`}
                 className="rounded-tag border border-status-expiring-border bg-status-expiring-bg px-3 py-1"
               >
                 <Text className="text-xs text-status-expiring">


### PR DESCRIPTION
## 요약

레시피 카드 재료 칩을 "재료 충분" 고정 표시에서 보유 재료명 + +N 오버플로우 방식으로 개선하고, 매칭률 뱃지 색상 기준 단순화

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #112 

## 작업 세부사항

**entities**

  - `recipe/model/recipe-mappers.ts` — `toRecipeCardData`에서 사용되지 않던 `_matched` 변수를 실제 `allIngredients`에 반영. 보유 재료가 없을 경우 전체 재료 목록으로 fallback
  - `recipe/ui/parts/IngredientChipsRow.tsx` — "재료 충분" 칩 및 `showEnoughChip` prop 제거
  - `recipe/ui/parts/BannerCardContent.tsx` — `showEnoughChip` prop 전달 제거
  - `recipe/ui/parts/DefaultCardContent.tsx` — `showEnoughChip` prop 전달 제거
  - `recipe/ui/parts/MatchRateBadge.tsx` — 매칭률 색상 기준 단순화: 80% 이상 초록, 나머지 회색 (주황 구간 제거)   

  **features**

  - `home-feed/api/get-fridge-recipes.ts` — 홈피드 전용 매퍼에도 동일한 `allIngredients` 버그 수정 적용

## 참고사항

`allIngredients`가 매퍼에서 계산만 되고 반환 객체에 포함되지 않아(`_matched`) 카드 칩이 항상 비어 "재료 충분"으로 표시되던 버그가 근본 원인입니다. 이번 PR에서 해당 버그를 수정하면서 칩 UI 방식을 함께 변경했습니다.   

매칭률 주황 구간(50~79%)은 `status-soon` 토큰(유통기한 임박 표시 용도)을 재사용하던 방식으로, 의미 충돌이 있어 제거했습니다.

  ## 변경 파일

```text
src/
├── entities/
│   └── recipe/
│       ├── model/
│       │   └── recipe-mappers.ts           # 수정
│       └── ui/
│           └── parts/
│               ├── BannerCardContent.tsx   # 수정
│               ├── DefaultCardContent.tsx  # 수정
│               ├── IngredientChipsRow.tsx  # 수정
│               └── MatchRateBadge.tsx      # 수정
└── features/
    └── home-feed/
        └── api/
            └── get-fridge-recipes.ts       # 수정
```