### PR TITLE
[fix/#115] 레시피 상세 재료 중복 key 경고 수정

### DIFF
--- a/src/entities/recipe/model/recipe-mappers.ts
+++ b/src/entities/recipe/model/recipe-mappers.ts
@@ -36,12 +36,19 @@ function toDifficulty(val: string): "쉬움" | "보통" | "어려움" {
 }
 
 export function toRecipe(dto: RecipeInfoDTO): Recipe {
-  const ingredients: Ingredient[] = dto.ingredients.map((ing) => ({
-    name: ing.name,
-    // TODO: 냉장고 재료와 대조해 owned 구분 — 현재는 API에서 제공하지 않아 일괄 true 처리
-    owned: true,
-    amount: ing.amount ?? undefined,
-  }));
+  const seen = new Set<string>();
+  const ingredients: Ingredient[] = dto.ingredients
+    .filter((ing) => {
+      if (seen.has(ing.name)) return false;
+      seen.add(ing.name);
+      return true;
+    })
+    .map((ing) => ({
+      name: ing.name,
+      // TODO: 냉장고 재료와 대조해 owned 구분 — 현재는 API에서 제공하지 않아 일괄 true 처리
+      owned: true,
+      amount: ing.amount ?? undefined,
+    }));
 
   const steps: CookingStep[] = dto.steps.map((step) => ({
     step: step.order,


### PR DESCRIPTION
## 요약

- 백엔드 응답에 동일 재료명이 중복 포함될 때 발생하는 React key 충돌 경고 수정

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #115 

## 작업 세부사항
- entities
  - `toRecipe` 매퍼에서 재료 배열을 이름 기준으로 중복 제거 처리 추가 (Set 활용, 첫 번째 항목 유지)

## 참고사항
중복 제거는 프론트 임시 대응이며, 근본 원인은 백엔드가 동일 재료를 중복으로 내려주는 것입니다. 추후 백엔드에서  
수정되면 이 처리는 제거해도 무방합니다.

## 변경 파일
  ```text
  src/
  └── entities/
      └── recipe/
          └── model/
              └── recipe-mappers.ts    # 수정
  ```