### PR TITLE
[fix/#117] 냉장고 중복 재료 제거, 메인페이지 및 레시피 상세 페이지 개선

### DIFF
--- a/src/entities/fridge/model/fridge-item-mappers.ts
+++ b/src/entities/fridge/model/fridge-item-mappers.ts
@@ -46,23 +46,24 @@ const SHELF_ORDER: ShelfType[] = [
 /**
  * FridgeItem 배열을 ShelfType 기준으로 그룹핑한 Record.
  * 항상 5개 ShelfType 키를 모두 포함하며, 아이템 없는 섹션은 items: []
+ * 같은 이름의 재료는 중복 제거하여 첫 번째 항목만 표시한다.
  */
 export function groupItemsToSections(items: FridgeItem[]): Record<ShelfType, FridgeSection> {
-  const grouped = new Map<ShelfType, FridgeItem[]>();
+  const grouped = new Map<ShelfType, Map<string, FridgeItem>>();
 
   for (const item of items) {
-    const existing = grouped.get(item.shelfType);
-    if (existing) {
-      existing.push(item);
-    } else {
-      grouped.set(item.shelfType, [item]);
+    const section = grouped.get(item.shelfType) || new Map<string, FridgeItem>();
+    // name 기준으로 중복 체크 — 첫 번째만 유지
+    if (!section.has(item.name)) {
+      section.set(item.name, item);
     }
+    grouped.set(item.shelfType, section);
   }
 
   return Object.fromEntries(
     SHELF_ORDER.map((type) => [
       type,
-      { type, ...SHELF_METADATA[type], items: grouped.get(type) ?? [] },
+      { type, ...SHELF_METADATA[type], items: Array.from(grouped.get(type)?.values() ?? []) },
     ]),
   ) as Record<ShelfType, FridgeSection>;
 }

--- a/src/features/home-feed/ui/BestMatchingSection.tsx
+++ b/src/features/home-feed/ui/BestMatchingSection.tsx
@@ -1,12 +1,11 @@
 // Best matching recipe section — displays first recipe from scrap recommendations as banner.
 
+import { router } from "expo-router";
 import { Text, View } from "react-native";
 
 import { BannerFoodCard } from "@/entities/recipe";
 import { RecipeLikedButton } from "@/features/recipe-liked-button";
 import { useScrapRecommendedRecipes } from "../model/use-scrap-recommended-recipes";
-
-const ALERT_STUB = () => alert("준비중입니다");
 
 export function BestMatchingSection() {
   const recipes = useScrapRecommendedRecipes();
@@ -23,7 +22,7 @@ export function BestMatchingSection() {
   return (
     <BannerFoodCard
       recipe={bestRecipe}
-      onPress={ALERT_STUB}
+      onPress={() => router.push(`/(protected)/recipe/${bestRecipe.recipeId}`)}
       likeButton={
         <RecipeLikedButton recipeId={bestRecipe.recipeId} initialLiked={bestRecipe.isLiked} />
       }

--- a/src/features/home-feed/ui/RecommendedSection.tsx
+++ b/src/features/home-feed/ui/RecommendedSection.tsx
@@ -1,5 +1,7 @@
 // Recommended recipes section with direct data fetching (Suspense-ready).
+import { router } from "expo-router";
 import { Text, View } from "react-native";
+import type { RecipeCardData } from "@/entities/recipe";
 import { RecipeList } from "@/widgets/RecipeList";
 import { useRecommendedRecipes } from "../model/use-recommended-recipes";
 
@@ -14,5 +16,9 @@ export function RecommendedSection() {
     );
   }
 
-  return <RecipeList recipes={recommendedRecipes} />;
+  const handlePressRecipe = (recipe: RecipeCardData) => {
+    router.push(`/(protected)/recipe/${recipe.recipeId}`);
+  };
+
+  return <RecipeList recipes={recommendedRecipes} onPressRecipe={handlePressRecipe} />;
 }

--- a/src/features/home-feed/ui/ScrapRecommendedSection.tsx
+++ b/src/features/home-feed/ui/ScrapRecommendedSection.tsx
@@ -1,7 +1,9 @@
 // Scrap-based recommended recipes section — displays remaining 4 recipes as recipe list.
 
+import { router } from "expo-router";
 import { Text, View } from "react-native";
 
+import type { RecipeCardData } from "@/entities/recipe";
 import { RecipeList } from "@/widgets/RecipeList";
 import { useScrapRecommendedRecipes } from "../model/use-scrap-recommended-recipes";
 
@@ -19,5 +21,9 @@ export function ScrapRecommendedSection() {
   // 나머지 4개 (첫 번째 제외)
   const remainingRecipes = recipes.slice(1, 5);
 
-  return <RecipeList recipes={remainingRecipes} />;
+  const handlePressRecipe = (recipe: RecipeCardData) => {
+    router.push(`/(protected)/recipe/${recipe.recipeId}`);
+  };
+
+  return <RecipeList recipes={remainingRecipes} onPressRecipe={handlePressRecipe} />;
 }

--- a/src/pages/recipe-detail/ui/RecipeDetailPage.tsx
+++ b/src/pages/recipe-detail/ui/RecipeDetailPage.tsx
@@ -1,10 +1,13 @@
 // src/pages/recipe-detail/ui/RecipeDetailPage.tsx
 // 레시피 상세 페이지. 히어로 이미지, 메타 정보, 재료, 조리 순서를 순서대로 표시.
 
-import { ActivityIndicator, ScrollView, Text, View } from "react-native";
+import { router } from "expo-router";
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useRecipeDetailQuery, useRecipeScrap } from "@/features/recipe-detail";
 import { tokens } from "@/shared/config/tokens";
+import { IconSymbol } from "@/shared/ui/icon-symbol";
 import { RecipeHero, RecipeIngredients, RecipeMeta, RecipeSteps } from "@/widgets/RecipeDetail";
 
 interface RecipeDetailPageProps {
@@ -18,17 +21,17 @@ export function RecipeDetailPage({ recipeId }: RecipeDetailPageProps) {
 
   if (isLoading) {
     return (
-      <View className="flex-1 items-center justify-center bg-surface-app">
+      <SafeAreaView className="flex-1 items-center justify-center bg-surface-app">
         <ActivityIndicator color={tokens.color["content-primary"]} />
-      </View>
+      </SafeAreaView>
     );
   }
 
   if (isError || !recipe) {
     return (
-      <View className="flex-1 items-center justify-center bg-surface-app">
+      <SafeAreaView className="flex-1 items-center justify-center bg-surface-app">
         <Text className="text-base text-content-secondary">레시피를 찾을 수 없습니다.</Text>
-      </View>
+      </SafeAreaView>
     );
   }
 
@@ -36,24 +39,37 @@ export function RecipeDetailPage({ recipeId }: RecipeDetailPageProps) {
   const missingIngredients = recipe.ingredients.filter((i) => !i.owned);
 
   return (
-    <ScrollView className="flex-1 bg-surface-app" showsVerticalScrollIndicator={false}>
-      <RecipeHero
-        recipe={recipe}
-        onToggleScrap={() => toggleScrap(recipe.isScrapped)}
-        isScrapPending={isScrapPending}
-      />
-
-      <View className="px-screen py-6">
-        <RecipeMeta recipe={recipe} />
-
-        <View className="my-6 h-px bg-stroke-default" />
-
-        <RecipeIngredients owned={ownedIngredients} missing={missingIngredients} />
-
-        <View className="my-6 h-px bg-stroke-default" />
-
-        <RecipeSteps steps={recipe.steps} />
+    <SafeAreaView edges={["top"]} className="flex-1 bg-surface-app">
+      {/* 헤더 */}
+      <View className="flex-row items-center justify-between px-5 py-4">
+        <Pressable onPress={() => router.back()}>
+          <IconSymbol name="chevron.left" size={24} color={tokens.color["content-primary"]} />
+        </Pressable>
+        <Text className="flex-1 text-center text-xl font-semibold text-content-primary">
+          레시피 상세
+        </Text>
+        <View style={{ width: 24 }} />
       </View>
-    </ScrollView>
+
+      <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
+        <RecipeHero
+          recipe={recipe}
+          onToggleScrap={() => toggleScrap(recipe.isScrapped)}
+          isScrapPending={isScrapPending}
+        />
+
+        <View className="px-screen py-6">
+          <RecipeMeta recipe={recipe} />
+
+          <View className="my-6 h-px bg-stroke-default" />
+
+          <RecipeIngredients owned={ownedIngredients} missing={missingIngredients} />
+
+          <View className="my-6 h-px bg-stroke-default" />
+
+          <RecipeSteps steps={recipe.steps} />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }

--- a/src/widgets/RecipeDetail/RecipeHero.tsx
+++ b/src/widgets/RecipeDetail/RecipeHero.tsx
@@ -15,13 +15,11 @@ export function RecipeHero({ recipe, onToggleScrap, isScrapPending }: RecipeHero
   return (
     <View className="relative aspect-[4/3]">
       <Image source={{ uri: recipe.imageUrl }} className="h-full w-full" resizeMode="cover" />
-      {/* 하단 그라디언트 오버레이 */}
       <View
-        className="absolute bottom-0 left-0 right-0"
-        style={{ height: "60%", backgroundColor: "rgba(0,0,0,0.38)" }}
-      />
-      <View className="absolute bottom-5 left-5">
-        <Text className="mb-1 text-xs font-semibold text-white/80">
+        className="absolute bottom-0 left-0 right-0 px-5 pb-5"
+        style={{ backgroundColor: "rgba(0,0,0,0.38)" }}
+      >
+        <Text className="text-xs font-semibold text-white/80">
           {recipe.tags.map((t) => `#${t}`).join("  ")}
         </Text>
         <Text className="text-2xl font-extrabold text-white">{recipe.title}</Text>


### PR DESCRIPTION
## 요약                                                                                                                                                                             
  - 냉장고 탭에서 같은 이름의 재료는 첫 번째만 표시하도록 중복 제거 로직 추가                                                            
  - 메인페이지 레시피 카드 클릭 시 레시피 상세 페이지로 이동
  - 레시피 상세 페이지 UX 개선 (헤더, 뒤로가기, 오버레이)

  ## 관련 이슈

  - Closes #117

  ## 작업 세부사항

  - **냉장고 중복 제거**: \`groupItemsToSections()\` 함수에 이름 기준 중복 제거 로직 추가 (Map 사용)
  - **네비게이션 추가**:
    - BestMatchingSection: 베스트 매칭 레시피 카드 클릭 시 상세페이지로 이동
    - RecommendedSection: \"지금 바로 만들 수 있어요\" 섹션 카드 클릭 시 이동
    - ScrapRecommendedSection: \"이런 요리는 어때요?\" 섹션 카드 클릭 시 이동
  - **상세페이지 개선**:
    - SafeAreaView 적용으로 노치/상태바 대응
    - 커스텀 헤더 추가 (뒤로가기 버튼 + \"레시피 상세\" 제목)
    - 히어로 이미지 하단 오버레이를 글자 크기에 맞게 자동 조정

  ## 참고사항

  - 라우팅 경로: \`/(protected)/recipe/{recipeId}\`
  - 중복 제거는 같은 이름 기준으로 첫 번째 항목만 유지
  - 오버레이는 콘텐츠에 맞춰 자동으로 높이 조정"
