### PR TITLE
[fix/#119] 알레르기·제외 재료 부분 문자열 필터링 보완

### DIFF
--- a/src/features/search-recipe/model/useRecipeSearch.ts
+++ b/src/features/search-recipe/model/useRecipeSearch.ts
@@ -83,17 +83,29 @@ export function useRecipeSearch() {
     addFridgeIngredientTags,
     fridgeRecipes: fridgeQuery.data ?? [],
     missingRecipes: missingQuery.data ?? [],
-    searchResults: (searchQuery.data ?? []).map((recipe) => {
-      const includeSet = new Set(includeTags.map((t) => t.label));
-      const allIngredients = recipe.allIngredients ?? [];
-      return {
-        ...recipe,
-        allIngredients: [
-          ...allIngredients.filter((i) => includeSet.has(i)),
-          ...allIngredients.filter((i) => !includeSet.has(i)),
-        ],
-      };
-    }),
+    searchResults: (searchQuery.data ?? [])
+      .filter((recipe) => {
+        if (excludeIngredients.length === 0) return true;
+        const allIngredients = recipe.allIngredients ?? [];
+        // 백엔드 exact match 보완: 제외 재료가 부분 문자열로 포함된 레시피 클라이언트 사이드 필터링
+        // allIngredients(보유 재료)와 missingIngredients(미보유 재료) 모두 체크해야 전체 재료 커버
+        const missingIngredients = recipe.missingIngredients ?? [];
+        const allRecipeIngredients = [...allIngredients, ...missingIngredients];
+        return !excludeIngredients.some((excl) =>
+          allRecipeIngredients.some((ing) => ing.includes(excl)),
+        );
+      })
+      .map((recipe) => {
+        const includeSet = new Set(includeTags.map((t) => t.label));
+        const allIngredients = recipe.allIngredients ?? [];
+        return {
+          ...recipe,
+          allIngredients: [
+            ...allIngredients.filter((i) => includeSet.has(i)),
+            ...allIngredients.filter((i) => !includeSet.has(i)),
+          ],
+        };
+      }),
     isLoading: hasActiveTags
       ? searchQuery.isLoading
       : fridgeQuery.isLoading || missingQuery.isLoading,

--- a/src/features/search-recipe/model/useRecipeSearch.ts
+++ b/src/features/search-recipe/model/useRecipeSearch.ts
@@ -4,6 +4,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import type { RecipeCardData } from "@/entities/recipe";
 import { toRecipeCardData } from "@/entities/recipe";
 import type { IngredientTag } from "@/shared/ui/IngredientTagInput";
 import { getFridgeIngredients } from "../api/get-fridge-ingredients";
@@ -17,7 +18,22 @@ export const MISSING_RECIPES_QUERY_KEY = ["recipes", "fridge", "missing"] as con
 export const SEARCH_RECIPES_QUERY_KEY = (keyword: string, excludeIngredients: string[]) =>
   ["recipes", "search", keyword, excludeIngredients] as const;
 
-export function useRecipeSearch() {
+// 제외 재료 목록을 기준으로 부분 문자열 매칭 필터링 (백엔드 exact match 보완)
+// allIngredients(보유)와 missingIngredients(미보유) 전체 대상으로 체크
+// TODO: 백엔드 excludeIngredients가 부분 문자열 매칭을 지원하면 이 함수와 호출부 제거
+function filterByExcluded(recipes: RecipeCardData[], excludeList: string[]): RecipeCardData[] {
+  if (excludeList.length === 0) return recipes;
+  return recipes.filter((recipe) => {
+    const all = [...(recipe.allIngredients ?? []), ...(recipe.missingIngredients ?? [])];
+    return !excludeList.some((excl) => all.some((ing) => ing.includes(excl)));
+  });
+}
+
+export function useRecipeSearch({
+  externalExcludeIngredients = [],
+}: {
+  externalExcludeIngredients?: string[];
+} = {}) {
   const [tags, setTags] = useState<IngredientTag[]>([]);
 
   const includeTags = tags.filter((t) => t.type === "include");
@@ -26,6 +42,7 @@ export function useRecipeSearch() {
 
   const keyword = includeTags.map((t) => t.label).join(",");
   const excludeIngredients = excludeTags.map((t) => t.label);
+  const allExcludeIngredients = [...excludeIngredients, ...externalExcludeIngredients];
 
   function addTag(tag: IngredientTag) {
     setTags((prev) =>
@@ -81,31 +98,19 @@ export function useRecipeSearch() {
     fridgeIngredients: fridgeIngredientsQuery.data ?? [],
     isFridgeIngredientsLoading: fridgeIngredientsQuery.isLoading,
     addFridgeIngredientTags,
-    fridgeRecipes: fridgeQuery.data ?? [],
-    missingRecipes: missingQuery.data ?? [],
-    searchResults: (searchQuery.data ?? [])
-      .filter((recipe) => {
-        if (excludeIngredients.length === 0) return true;
-        const allIngredients = recipe.allIngredients ?? [];
-        // 백엔드 exact match 보완: 제외 재료가 부분 문자열로 포함된 레시피 클라이언트 사이드 필터링
-        // allIngredients(보유 재료)와 missingIngredients(미보유 재료) 모두 체크해야 전체 재료 커버
-        const missingIngredients = recipe.missingIngredients ?? [];
-        const allRecipeIngredients = [...allIngredients, ...missingIngredients];
-        return !excludeIngredients.some((excl) =>
-          allRecipeIngredients.some((ing) => ing.includes(excl)),
-        );
-      })
-      .map((recipe) => {
-        const includeSet = new Set(includeTags.map((t) => t.label));
-        const allIngredients = recipe.allIngredients ?? [];
-        return {
-          ...recipe,
-          allIngredients: [
-            ...allIngredients.filter((i) => includeSet.has(i)),
-            ...allIngredients.filter((i) => !includeSet.has(i)),
-          ],
-        };
-      }),
+    fridgeRecipes: filterByExcluded(fridgeQuery.data ?? [], allExcludeIngredients),
+    missingRecipes: filterByExcluded(missingQuery.data ?? [], allExcludeIngredients),
+    searchResults: filterByExcluded(searchQuery.data ?? [], allExcludeIngredients).map((recipe) => {
+      const includeSet = new Set(includeTags.map((t) => t.label));
+      const allIngredients = recipe.allIngredients ?? [];
+      return {
+        ...recipe,
+        allIngredients: [
+          ...allIngredients.filter((i) => includeSet.has(i)),
+          ...allIngredients.filter((i) => !includeSet.has(i)),
+        ],
+      };
+    }),
     isLoading: hasActiveTags
       ? searchQuery.isLoading
       : fridgeQuery.isLoading || missingQuery.isLoading,

--- a/src/pages/search/ui/SearchPage.tsx
+++ b/src/pages/search/ui/SearchPage.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "expo-router";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 
 import { useRecipeSearch } from "@/features/search-recipe";
+import { usePreferencesStore } from "@/features/user-preferences";
 import { tokens } from "@/shared/config/tokens";
 import { IngredientTagInput } from "@/shared/ui/IngredientTagInput";
 import { IconSymbol } from "@/shared/ui/icon-symbol";
@@ -30,6 +31,14 @@ export function SearchPage() {
     isLoading,
     isError,
   } = useRecipeSearch();
+  const { allergies } = usePreferencesStore();
+
+  // 알레르기 등록 재료를 부분 문자열로 포함한 레시피 자동 제외
+  const allergyFilteredResults = searchResults.filter((recipe) => {
+    if (allergies.length === 0) return true;
+    const all = [...(recipe.allIngredients ?? []), ...recipe.missingIngredients];
+    return !allergies.some((allergy) => all.some((ing) => ing.includes(allergy)));
+  });
 
   const handlePressRecipe = (recipe: { recipeId: number }) =>
     router.push(`/recipe/${recipe.recipeId}`);
@@ -94,12 +103,12 @@ export function SearchPage() {
           {/* 태그 검색 중: 결과 카운트 */}
           {hasActiveTags && (
             <Text className="mb-2 mt-4 text-xs text-content-secondary">
-              검색 결과 {searchResults.length}개
+              검색 결과 {allergyFilteredResults.length}개
             </Text>
           )}
 
           {/* 검색 결과 없음 */}
-          {hasActiveTags && searchResults.length === 0 && (
+          {hasActiveTags && allergyFilteredResults.length === 0 && (
             <View className="mt-20 items-center gap-3">
               <View className="h-14 w-14 items-center justify-center rounded-2xl bg-surface-section">
                 <IconSymbol
@@ -113,9 +122,9 @@ export function SearchPage() {
           )}
 
           {/* 태그 검색 결과 */}
-          {hasActiveTags && searchResults.length > 0 && (
+          {hasActiveTags && allergyFilteredResults.length > 0 && (
             <View className="mt-4">
-              <RecipeList recipes={searchResults} onPressRecipe={handlePressRecipe} />
+              <RecipeList recipes={allergyFilteredResults} onPressRecipe={handlePressRecipe} />
             </View>
           )}
 

--- a/src/pages/search/ui/SearchPage.tsx
+++ b/src/pages/search/ui/SearchPage.tsx
@@ -16,6 +16,7 @@ import { OthersSection, RecommendedSection } from "@/widgets/RecipeSearch";
 
 export function SearchPage() {
   const router = useRouter();
+  const { allergies } = usePreferencesStore();
   const {
     tags,
     addTag,
@@ -30,15 +31,7 @@ export function SearchPage() {
     searchResults,
     isLoading,
     isError,
-  } = useRecipeSearch();
-  const { allergies } = usePreferencesStore();
-
-  // 알레르기 등록 재료를 부분 문자열로 포함한 레시피 자동 제외
-  const allergyFilteredResults = searchResults.filter((recipe) => {
-    if (allergies.length === 0) return true;
-    const all = [...(recipe.allIngredients ?? []), ...recipe.missingIngredients];
-    return !allergies.some((allergy) => all.some((ing) => ing.includes(allergy)));
-  });
+  } = useRecipeSearch({ externalExcludeIngredients: allergies });
 
   const handlePressRecipe = (recipe: { recipeId: number }) =>
     router.push(`/recipe/${recipe.recipeId}`);
@@ -103,12 +96,12 @@ export function SearchPage() {
           {/* 태그 검색 중: 결과 카운트 */}
           {hasActiveTags && (
             <Text className="mb-2 mt-4 text-xs text-content-secondary">
-              검색 결과 {allergyFilteredResults.length}개
+              검색 결과 {searchResults.length}개
             </Text>
           )}
 
           {/* 검색 결과 없음 */}
-          {hasActiveTags && allergyFilteredResults.length === 0 && (
+          {hasActiveTags && searchResults.length === 0 && (
             <View className="mt-20 items-center gap-3">
               <View className="h-14 w-14 items-center justify-center rounded-2xl bg-surface-section">
                 <IconSymbol
@@ -122,9 +115,9 @@ export function SearchPage() {
           )}
 
           {/* 태그 검색 결과 */}
-          {hasActiveTags && allergyFilteredResults.length > 0 && (
+          {hasActiveTags && searchResults.length > 0 && (
             <View className="mt-4">
-              <RecipeList recipes={allergyFilteredResults} onPressRecipe={handlePressRecipe} />
+              <RecipeList recipes={searchResults} onPressRecipe={handlePressRecipe} />
             </View>
           )}
 


### PR DESCRIPTION
## 요약
- 알레르기·제외 태그가 "오이" → "백오이", "가시오이" 등 파생 재료명을 걸러내지 못하는 문제 수정
- 마이페이지 알레르기 등록 시 검색 결과에 자동 반영되지 않던 문제 수정

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #119 

## 작업 세부사항
- useRecipeSearch: excludeIngredients 대상으로 클라이언트 사이드 substring 필터링 추가
  - 백엔드 exact match 보완용 2차 필터
  - allIngredients(보유 재료)뿐 아니라 missingIngredients(미보유 재료)까지 함께 체크
- SearchPage: usePreferencesStore에서 알레르기 목록을 읽어 검색 결과에 자동 적용
  - 알레르기도 동일하게 substring 매칭으로 처리

## 참고사항
  - 백엔드가 1차 필터링 후 응답, 프론트에서 2차 방어 필터로 동작
  - FSD 레이어 규칙 준수: features/user-preferences import는 page 레이어(SearchPage)에서만 수행