### PR TITLE
[fix/#121] 냉장고 재료 수 중복 불일치 수정

### DIFF
--- a/src/features/search-recipe/model/useRecipeSearch.ts
+++ b/src/features/search-recipe/model/useRecipeSearch.ts
@@ -63,9 +63,12 @@ export function useRecipeSearch({
     queryFn: getFridgeIngredients,
   });
 
+  const uniqueFridgeIngredients = [
+    ...new Map((fridgeIngredientsQuery.data ?? []).map((i) => [i.name, i])).values(),
+  ];
+
   function addFridgeIngredientTags() {
-    const items = fridgeIngredientsQuery.data ?? [];
-    for (const item of items) {
+    for (const item of uniqueFridgeIngredients) {
       addTag({ id: `fridge-${item.id}`, label: item.name, type: "include" });
     }
   }
@@ -95,9 +98,7 @@ export function useRecipeSearch({
     removeTag,
     clearTags,
     hasActiveTags,
-    fridgeIngredients: [
-      ...new Map((fridgeIngredientsQuery.data ?? []).map((i) => [i.name, i])).values(),
-    ],
+    fridgeIngredients: uniqueFridgeIngredients,
     isFridgeIngredientsLoading: fridgeIngredientsQuery.isLoading,
     addFridgeIngredientTags,
     fridgeRecipes: filterByExcluded(fridgeQuery.data ?? [], allExcludeIngredients),

--- a/src/features/search-recipe/model/useRecipeSearch.ts
+++ b/src/features/search-recipe/model/useRecipeSearch.ts
@@ -95,7 +95,9 @@ export function useRecipeSearch({
     removeTag,
     clearTags,
     hasActiveTags,
-    fridgeIngredients: fridgeIngredientsQuery.data ?? [],
+    fridgeIngredients: [
+      ...new Map((fridgeIngredientsQuery.data ?? []).map((i) => [i.name, i])).values(),
+    ],
     isFridgeIngredientsLoading: fridgeIngredientsQuery.isLoading,
     addFridgeIngredientTags,
     fridgeRecipes: filterByExcluded(fridgeQuery.data ?? [], allExcludeIngredients),

--- a/src/widgets/fridge-status-bar/ui/FridgeStatusBar.tsx
+++ b/src/widgets/fridge-status-bar/ui/FridgeStatusBar.tsx
@@ -13,6 +13,7 @@ export function FridgeStatusBar() {
 
   const scrapsCount = scraps.length;
   const allergiesCount = userProfile?.allergies.length ?? 0;
+  const uniqueItemsCount = new Set(items.map((i) => i.name)).size;
 
   const STATUS_ITEMS = [
     { label: "찜레시피", value: `${scrapsCount}개` },
@@ -20,7 +21,7 @@ export function FridgeStatusBar() {
   ];
 
   const STATUS_ITEMS_WITH_TOTAL = [
-    { label: "총 재료", value: `${items.length}개` },
+    { label: "총 재료", value: `${uniqueItemsCount}개` },
     ...STATUS_ITEMS,
   ];
 


### PR DESCRIPTION
## 요약

- 냉장고 화면·메인 페이지·검색 페이지에서 재료 수가 각각 다르게 표시되는 불일치 수정

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #121 

## 작업 세부사항
  - FridgeStatusBar: items.length → new Set(items.map(i => i.name)).size 로 변경, name 기준 unique count 사용       
  - useRecipeSearch: fridgeIngredients 반환 시 name 기준 dedup 처리, 버튼 카운트·태그 수·실제 검색 키워드 일치 

## 참고사항
  - 냉장고 화면은 기존부터 groupItemsToSections에서 name 기준 중복 제거 적용 중, 이번 수정으로 전체 화면 일관성 확보