### PR TITLE
[fix/#123] 찜한 레시피 카드 조리시간·난이도 fallback 수정

### DIFF
--- a/src/features/liked-recipes/api/get-scraps.ts
+++ b/src/features/liked-recipes/api/get-scraps.ts
@@ -26,8 +26,8 @@ export async function getScraps(): Promise<RecipeCardData[]> {
     matchRate: 0,
     allIngredients: [],
     missingIngredients: [],
-    cookTime: "0분",
-    difficulty: "정보없음",
+    cookTime: undefined,
+    difficulty: undefined,
     isLiked: true,
   }));
 }

--- a/src/features/liked-recipes/api/get-scraps.ts
+++ b/src/features/liked-recipes/api/get-scraps.ts
@@ -22,7 +22,7 @@ export async function getScraps(): Promise<RecipeCardData[]> {
     recipeId: scrap.recipeId,
     title: scrap.title,
     mainImage: scrap.thumbnailUrl,
-    category: "카테고리",
+    category: undefined,
     matchRate: 0,
     allIngredients: [],
     missingIngredients: [],


### PR DESCRIPTION
## 요약

- 찜한 레시피 카드에 조리시간 "0분", 난이도 "정보없음"이 표시되는 문제 수정

## 관련 이슈

<!-- PR 머지 시 자동으로 이슈가 닫힙니다. 예: Closes #123 -->
- Closes #123 

## 작업 세부사항

- getScraps: cookTime, difficulty 하드코딩 값("0분", "정보없음") → undefined 로 변경
- RecipeMetaRow 기존 fallback("60분 이내", "아무나")이 자연스럽게 적용되어 검색 페이지와 동일하게 표시

## 참고사항

- 근본 해결은 백엔드에서 /users/me/scraps 응답에 cookTime, difficulty 필드를 포함시키는 것

<img width="756" height="1493" alt="image" src="https://github.com/user-attachments/assets/48ba77f1-7204-46ad-946f-6e99c74dd6d4" />
